### PR TITLE
Don't ignore last word of fastbus banks.

### DIFF
--- a/hana_decode/FastbusModule.C
+++ b/hana_decode/FastbusModule.C
@@ -58,7 +58,6 @@ Int_t FastbusModule::LoadSlot(THaSlotData *sldat, const UInt_t* evbuffer, const 
      *fDebugFile << "FBModule::  Model number  "<<dec<<fModelNum<<endl;
   }
   while (IsSlot( *p )) {
-    if (p >= pstop) break;
     if (fHasHeader && fWordsSeen==0) {
       fHeader = *p;
       if (fDebugFile) *fDebugFile << "FastbusModule:: header "<<hex<<fHeader<<dec<<endl;
@@ -69,6 +68,7 @@ Int_t FastbusModule::LoadSlot(THaSlotData *sldat, const UInt_t* evbuffer, const 
     }
     fWordsSeen++;
     p++;
+    if (p > pstop) break;
   }
   if (fHeader) {
     Int_t fWordsExpect = (fHeader&fWdcntMask);


### PR DESCRIPTION
The new decoder skips the last word of Fastbus banks.  Not sure if this is the best way, but this commit fixes it.