### PR TITLE
Check if slot is used.

### DIFF
--- a/hana_decode/CodaDecoder.C
+++ b/hana_decode/CodaDecoder.C
@@ -303,6 +303,7 @@ Int_t CodaDecoder::bank_decode( Int_t roc, const UInt_t* evbuffer,
   Int_t maxslot = fMap->getMaxSlot(roc);
 
   for (Int_t slot = minslot; slot <= maxslot; slot++) {
+    if (!fMap->slotUsed(roc,slot)) continue;
     bank=fMap->getBank(roc,slot);
     if (bank < 0 || bank >= Decoder::MAXBANK) {
       cerr << "CodaDecoder::ERROR:  bank number out of range "<<endl;


### PR DESCRIPTION
Added a check to the `CodaDecoder::bank_decode` which checks if slot is
used before getting the slot number. The problem is that the method
loops over all slots from `minslot` to `maxslot`, which is fine if all
slots are filled in the cratemap. If however one uses slot 8 and 10, but
not slot 9, this loop will get a `bank` default value of -1, which
doesn't pass further tests. Now a slot that is not used is just skipped.