### PR TITLE
Add lib*.dylib to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.d
 *.os
 lib*.so*
+lib*.dylib
 analyzer
 hana_decode/epicsd
 hana_decode/prfact


### PR DESCRIPTION
  Evio libs are .dylib on macosx