### PR TITLE
Prestarthandle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,9 @@ SRC          := src/THaFormula.C src/THaVform.C src/THaVhist.C \
 		src/THaPhotoReaction.C src/THaSAProtonEP.C \
 		src/THaTextvars.C src/THaQWEAKHelicity.C \
 		src/THaQWEAKHelicityReader.C src/THaEvtTypeHandler.C \
-		src/THaScalerEvtHandler.C src/THaEpicsEvtHandler.C
+		src/THaScalerEvtHandler.C src/THaEpicsEvtHandler.C \
+		src/THaEvt125Handler.C src/THaExampleEvtHandler.C
+
 
 # ifdef ONLINE_ET
 # SRC += src/THaOnlRun.C

--- a/SConscript.py
+++ b/SConscript.py
@@ -54,6 +54,7 @@ src/THaTrackOut.h src/THaTriggerTime.h src/THaHelicityDet.h src/THaG0HelicityRea
 src/THaG0Helicity.h src/THaADCHelicity.h src/THaHelicity.h src/THaPhotoReaction.h 
 src/THaSAProtonEP.h src/THaTextvars.h src/THaQWEAKHelicity.h src/THaQWEAKHelicityReader.h
 src/THaEvtTypeHandler.h src/THaScalerEvtHandler.h src/THaEpicsEvtHandler.h
+src/THaExampleEvtHandler.h src/THaEvt125Handler.h
 src/THaVDCChamber.h src/THaVDCPoint.h src/THaVDCPointPair.h
 src/THaGlobals.h src/HallA_LinkDef.h
 """)

--- a/src/HallA_LinkDef.h
+++ b/src/HallA_LinkDef.h
@@ -132,6 +132,8 @@
 #pragma link C++ class THaEvtTypeHandler+;
 #pragma link C++ class THaScalerEvtHandler+;
 #pragma link C++ class THaEpicsEvtHandler+;
+#pragma link C++ class THaEvt125Handler+;
+#pragma link C++ class THaExampleEvtHandler+;
 
 #ifdef ONLINE_ET
 #pragma link C++ class THaOnlRun+;

--- a/src/THaEvt125Handler.C
+++ b/src/THaEvt125Handler.C
@@ -1,0 +1,138 @@
+////////////////////////////////////////////////////////////////////
+//
+//   THaEvt125Handler
+//   author  Robert Michaels (rom@jlab.org), Jan 2017
+//
+//   Example of an Event Type Handler for event type 125,
+//   the hall C prestart event.
+//
+//   It was tested on some hms data.  However, note that I don't know what 
+//   these data mean yet and I presume the data structure is under development; 
+//   someone will need to modify this class (and the comments).
+//
+//   To use as a plugin with your own modifications, you can do this in
+//   your analysis script
+//    
+//   gHaEvtHandlers->Add (new THaEvt125Handler("hallcpre","for evtype 125"));
+//
+//   Global variables are defined in Init.  You can see them in Podd, as
+//     analyzer [2] gHaVars->Print()
+//
+//      OBJ: THaVar	HCvar1	Hall C event type 125 variable 1
+//      OBJ: THaVar	HCvar2	Hall C event type 125 variable 2
+//      OBJ: THaVar	HCvar3	Hall C event type 125 variable 3
+//      OBJ: THaVar	HCvar4	Hall C event type 125 variable 4
+//
+//   The data can be added to the ROOT Tree "T" using the output
+//   definition file.  Then you can see them, for example as follows
+// 
+//      T->Scan("HCvar1:HCvar2:HCvar3:HCvar4")
+//
+/////////////////////////////////////////////////////////////////////
+
+#include "THaEvtTypeHandler.h"
+#include "THaEvt125Handler.h"
+#include "THaCodaData.h"
+#include "THaEvData.h"
+#include "THaEpics.h"
+#include "TNamed.h"
+#include "TMath.h"
+#include "TString.h"
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include "THaVarList.h"
+#include "VarDef.h"
+
+using namespace std;
+using namespace Decoder;
+
+THaEvt125Handler::THaEvt125Handler(const char *name, const char* description)
+  : THaEvtTypeHandler(name,description)
+{
+}
+
+THaEvt125Handler::~THaEvt125Handler()
+{
+
+}
+
+Int_t THaEvt125Handler::End( THaRunBase* r)
+{
+  return 0;
+}
+
+// A public method which other classes may use
+Float_t THaEvt125Handler::GetData(std::string tag) {
+  if (theDataMap.find(tag) != theDataMap.end()) return theDataMap[tag];
+  return 0;
+}
+
+
+Int_t THaEvt125Handler::Analyze(THaEvData *evdata) 
+{
+
+  Int_t ldebug=1;
+  Int_t index;
+  Int_t startidx = 3;
+
+  if ( !IsMyEvent(evdata->GetEvType()) ) return -1;
+
+  if (ldebug) cout << "------------------\n  Event type 125 \n\n"<<endl;
+
+  for (Int_t i = 0; i < evdata->GetEvLength(); i++) {
+
+    if (ldebug) cout << "data["<<dec<<i<<"] =  0x"<<hex<<evdata->GetRawData(i)<<"  = decimal "<<dec<<evdata->GetRawData(i)<<endl;
+
+// This is a fake example of how to decode.  Modify it as you wish,
+// and then change these comments.
+// The data in "dvars" appears as global variables.
+
+    if (i >= startidx) {
+      index = i-startidx;
+      if (index >=0 && index < NVars) dvars[index] = evdata->GetRawData(i);
+    }
+
+  }      
+
+  return 1;
+}
+
+
+THaAnalysisObject::EStatus THaEvt125Handler::Init(const TDatime& date)
+{
+
+  cout << "Howdy !  We are initializing THaEvt125Handler !!   name =   "<<fName<<endl;
+
+  eventtypes.push_back(125);  // what events to look for
+
+// dvars is a member of this class.
+// The index of the dvars array track the array of global variables created.
+// This is just a fake example with 4 variables.
+// Please change these comments when you modify this class.
+
+  NVars = 4;
+  dvars = new Double_t[NVars];
+  memset(dvars, 0, NVars*sizeof(Double_t));
+  if (gHaVars) {
+      cout << "EvtHandler:: Have gHaVars.  Good thing. "<<gHaVars<<endl;
+  } else {
+      cout << "EvtHandler:: No gHaVars ?!  Well, that is a problem !!"<<endl;
+  }
+  const Int_t* count = 0;
+  char cname[80];
+  char cdescription[80];
+  for (UInt_t i = 0; i < NVars; i++) {
+    sprintf(cname,"HCvar%d",i+1);
+    sprintf(cdescription,"Hall C event type 125 variable %d",i+1);
+    gHaVars->DefineByType(cname, cdescription, &dvars[i], kDouble, count);
+  }
+
+
+  fStatus = kOK;
+  return kOK;
+}
+
+ClassImp(THaEvt125Handler)

--- a/src/THaEvt125Handler.h
+++ b/src/THaEvt125Handler.h
@@ -1,0 +1,50 @@
+#ifndef THaEvt125Handler_
+#define THaEvt125Handler_
+
+/////////////////////////////////////////////////////////////////////
+//
+//   THaEvt125Handler
+//   For more details see the implementation file.
+//   This handles hall C's event type 125.
+//   author  Robert Michaels (rom@jlab.org)
+//
+/////////////////////////////////////////////////////////////////////
+
+#include "THaEvtTypeHandler.h"
+#include "Decoder.h"
+#include <string>
+#include <vector>
+#include <map>
+#include <iterator>
+#include "TTree.h"
+#include "TString.h"  
+
+class THaEvt125Handler : public THaEvtTypeHandler {
+
+public:
+
+   THaEvt125Handler(const char* name, const char* description);
+   virtual ~THaEvt125Handler();
+
+   virtual Int_t Analyze(THaEvData *evdata);
+   virtual EStatus Init( const TDatime& run_time);
+   virtual Int_t End( THaRunBase* r=0 );
+   Float_t GetData(std::string tag);  
+
+private:
+
+   static const Int_t MAXDATA=20000;
+
+   std::map<std::string, Float_t> theDataMap;
+   std::vector<std::string> dataKeys;
+   Int_t NVars;
+   Double_t *dvars; 
+
+   THaEvt125Handler(const THaEvt125Handler& fh);
+   THaEvt125Handler& operator=(const THaEvt125Handler& fh);
+
+   ClassDef(THaEvt125Handler,0)  // Hall C event type 125
+
+};
+
+#endif

--- a/src/THaExampleEvtHandler.h
+++ b/src/THaExampleEvtHandler.h
@@ -1,0 +1,49 @@
+#ifndef THaExampleEvtHandler_
+#define THaExampleEvtHandler_
+
+/////////////////////////////////////////////////////////////////////
+//
+//   THaExampleEvtHandler
+//   For more details see the implementation file.
+//   The idea would be to copy this and modify it for your purposes.
+//   author  Robert Michaels (rom@jlab.org)
+//
+/////////////////////////////////////////////////////////////////////
+
+#include "THaEvtTypeHandler.h"
+#include "Decoder.h"
+#include <string>
+#include <vector>
+#include <map>
+#include <iterator>
+#include "TTree.h"
+#include "TString.h"  
+
+class THaExampleEvtHandler : public THaEvtTypeHandler {
+
+public:
+
+   THaExampleEvtHandler(const char* name, const char* description);
+   virtual ~THaExampleEvtHandler();
+
+   virtual Int_t Analyze(THaEvData *evdata);
+   virtual EStatus Init( const TDatime& run_time);
+   virtual Int_t End( THaRunBase* r=0 );
+   Float_t GetData(std::string tag);  
+
+private:
+
+   static const Int_t MAXDATA=20000;
+
+   std::map<std::string, Float_t> theDataMap;
+   std::vector<std::string> dataKeys;
+   Double_t *dvars; 
+
+   THaExampleEvtHandler(const THaExampleEvtHandler& fh);
+   THaExampleEvtHandler& operator=(const THaExampleEvtHandler& fh);
+
+   ClassDef(THaExampleEvtHandler,0)  // Example of an Event handler
+
+};
+
+#endif


### PR DESCRIPTION
Added two new classes:  THaExampleEvtHandler and THaEvt125Handler. The former is a generic example which can be copied and imitated. The latter is a simple first version of the hall C prestart event
handler. Both are documented in the implementation file (*.C). A few other files are affected, like HallA_LinkDef.h, Makefile, and SConscript.py.  I noticed when running this in Podd that THaRunBase would return READ_FATAL when a "hall A prestart event" was not found; I had to kluge this (return READ_OK instead). Perhaps it won't affect hcana, though.
