### PR TITLE
Change travis build from make to latest version of scons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y x11-common libx11-6 x11-utils gsl-bin libxpm4 libxft2 libpng3 libjpeg-turbo8 libjpeg8 libtiff4 libxml2 libldap-2.4-2 libkrb5-3 freeglut3 libfftw3-3 python libmysqlclient18 libgif4 libiodbc2 libxext6 libxmu6 libimlib2 gccxml wget libpopt-dev libc6-dev-i386
   - sudo apt-get autoremove
+  - sudo pip install --egg scons
 install:
   - wget http://root.cern.ch/download/root_v5.34.32.Linux-ubuntu12-x86_64-gcc4.6.tar.gz -O /tmp/root.tar.gz
   - tar -xzf /tmp/root.tar.gz
   - source ./root/bin/thisroot.sh
-script:  make
+script:  scons
 branches:
   only: master
 notifications:


### PR DESCRIPTION
This switches the build method for TravisCI from make to scons.  It also insures that the latest version of scons is used.  This latest version is needed for the coming improvements to the scons build system for analyzer.