### PR TITLE
Remove fNumChan from GenScaler.h - already defined in Module.h

### DIFF
--- a/hana_decode/GenScaler.h
+++ b/hana_decode/GenScaler.h
@@ -52,7 +52,7 @@ namespace Decoder {
     Bool_t fIsDecoded, fFirstTime, fDeltaT;
     Int_t *fDataArray, *fPrevData;
     Double_t *fRate;
-    Int_t fNumChan, fClockChan, fNumChanMask, fNumChanShift;
+    Int_t fClockChan, fNumChanMask, fNumChanShift;
     Bool_t fHasClock;
     Double_t fClockRate;
     GenScaler *fNormScaler;


### PR DESCRIPTION
  fNumChan definition in Module.h resulted in
  Module::GetNumChan() returning wrong value