### PR TITLE
Epics and bit17

### DIFF
--- a/hana_decode/Decoder.h
+++ b/hana_decode/Decoder.h
@@ -46,7 +46,7 @@ namespace Decoder {
   static const Int_t END_EVTYPE       = 20;
   static const Int_t TS_PRESCALE_EVTYPE  = 120;
   // should be able to load special event types from crate map
-  static const Int_t EPICS_EVTYPE     = 131;
+  static const Int_t EPICS_EVTYPE     = 131; // default in Hall A
   static const Int_t PRESCALE_EVTYPE  = 133;
   static const Int_t DETMAP_FILE      = 135;
   static const Int_t TRIGGER_FILE     = 136;

--- a/hana_decode/FastbusModule.h
+++ b/hana_decode/FastbusModule.h
@@ -28,9 +28,12 @@ public:
    virtual Int_t LoadSlot(THaSlotData *sldat, const UInt_t* evbuffer, const UInt_t *pstop);
    void DoPrint() const;
 
+   Int_t GetOpt(UInt_t rdata) { return Opt(rdata); };
+
    Int_t Slot(UInt_t rdata) { return (rdata>>fSlotShift); };
    Int_t Chan(UInt_t rdata) { return (rdata&fChanMask)>>fChanShift; };
    Int_t Data(UInt_t rdata) { return (rdata&fDataMask); };
+   Int_t Opt(UInt_t rdata) { return (rdata&fOptMask)>>fOptShift; };
 
 protected:
 

--- a/hana_decode/Module.h
+++ b/hana_decode/Module.h
@@ -50,6 +50,7 @@ namespace Decoder {
     virtual Int_t GetData(Int_t, Int_t, Int_t) const { return 0; };
     virtual Int_t GetData(Decoder::EModuleType type, Int_t chan, Int_t hit) const { return 0; };
     virtual Int_t GetData(Decoder::EModuleType type, Int_t chan, Int_t hit, Int_t sample) const {return 0;};
+    virtual Int_t GetOpt(UInt_t rdata) { return 0; }; 
 
     virtual Int_t Decode(const UInt_t *p) = 0; // implement in derived class
     // Loads slot data

--- a/hana_decode/THaEvData.C
+++ b/hana_decode/THaEvData.C
@@ -75,6 +75,7 @@ THaEvData::THaEvData() :
   //memset(psfact,0,MAX_PSFACT*sizeof(int));
   memset(crateslot,0,MAXROC*MAXSLOT*sizeof(THaSlotData*));
   fRunTime = time(0); // default fRunTime is NOW
+  fEpicsEvtType = Decoder::EPICS_EVTYPE;  // default for Hall A
 #ifndef STANDALONE
 // Register global variables.
   if( gHaVars ) {

--- a/hana_decode/THaEvData.h
+++ b/hana_decode/THaEvData.h
@@ -39,6 +39,9 @@ public:
 
   virtual Int_t Init();
 
+  // Set the EPICS event type
+  void      SetEpicsEvtType(Int_t itype) { fEpicsEvtType = itype; };
+
   // Basic access to the decoded data
   Int_t     GetEvType()   const { return event_type; }
   Int_t     GetEvLength() const { return event_length; }
@@ -116,6 +119,21 @@ public:
     } else {
       return GetData( crate, slot, chan, hit );
     }
+  }
+
+  Int_t GetLEbit(Int_t crate, Int_t slot, Int_t chan, Int_t hit ) const 
+  { // get the Leading Edge bit (works for fastbus)
+    return GetOpt(crate, slot, chan, hit );
+  }
+
+  Int_t GetOpt( Int_t crate, Int_t slot, Int_t chan, Int_t hit ) const 
+  {// get the "Opt" bit (works for fastbus, is otherwise zero)
+    Decoder::Module* module = GetModule(crate, slot);
+    if (!module) {
+      std::cout << "No module at crate "<<crate<<"   slot "<<slot<<std::endl;
+      return 0;
+    }
+    return module->GetOpt(GetRawData(crate, slot, hit));
   }
 
   // Optional functionality that may be implemented by derived classes
@@ -198,7 +216,7 @@ protected:
   // static const Int_t PAUSE_EVTYPE     = 19;
   // static const Int_t END_EVTYPE       = 20;
   // static const Int_t TS_PRESCALE_EVTYPE  = 120;
-  // static const Int_t EPICS_EVTYPE     = 131;
+  // static const Int_t EPICS_EVTYPE     = 131;  (default in Hall A)
   // static const Int_t PRESCALE_EVTYPE  = 133;
   // static const Int_t DETMAP_FILE      = 135;
   // static const Int_t TRIGGER_FILE     = 136;
@@ -213,6 +231,8 @@ protected:
   Bool_t first_decode;
   Bool_t fTrigSupPS;
   Bool_t  fMultiBlockMode, fBlockIsDone;
+
+  Int_t fEpicsEvtType;
 
   const UInt_t *buffer;
 
@@ -389,7 +409,7 @@ Bool_t THaEvData::IsPrestartEvent() const {
 
 inline
 Bool_t THaEvData::IsEpicsEvent() const {
-  return (event_type == Decoder::EPICS_EVTYPE);
+  return (event_type == fEpicsEvtType);
 };
 
 inline

--- a/src/THaAnalyzer.C
+++ b/src/THaAnalyzer.C
@@ -82,6 +82,7 @@ THaAnalyzer::THaAnalyzer() :
   fUpdateRun(kTRUE), fOverwrite(kTRUE), fDoBench(kFALSE),
   fDoHelicity(kFALSE), fDoPhysics(kTRUE), fDoOtherEvents(kTRUE),
   fDoSlowControl(kTRUE)
+
 {
   // Default constructor.
 
@@ -99,9 +100,10 @@ THaAnalyzer::THaAnalyzer() :
   fEvtHandlers = gHaEvtHandlers;
 
   // EPICs data
-  fEpicsHandler = new THaEpicsEvtHandler("epics","EPICS event type 131");
+  fEpicsHandler = new THaEpicsEvtHandler("epics","EPICS event type");
   //  fEpicsHandler->SetDebugFile("epicsdat.txt");
   fEvtHandlers->Add(fEpicsHandler);
+  
 
   // Timers
   fBench = new THaBenchmark;
@@ -839,6 +841,13 @@ Int_t THaAnalyzer::ReadOneEvent()
 }
 
 //_____________________________________________________________________________
+void THaAnalyzer::SetEpicsEvtType(Int_t itype)
+{
+    if (fEpicsHandler) fEpicsHandler->SetEvtType(itype);
+    if (fEvData) fEvData->SetEpicsEvtType(itype);
+};
+
+//_____________________________________________________________________________
 Int_t THaAnalyzer::SetCountMode( Int_t mode )
 {
   // Set event counting mode. The default mode is kCountPhysics.
@@ -1238,7 +1247,8 @@ Int_t THaAnalyzer::MainAnalysis()
     evdone = true;
   }
 
-  //=== EPICS data ===
+  //=== EPICS data === 
+  fEvData->SetEpicsEvtType(fEpicsHandler->GetEvtType());
   if( fEvData->IsEpicsEvent() && fDoSlowControl ) {
     Incr(kNevEpics);
     retval = SlowControlAnalysis(retval);

--- a/src/THaAnalyzer.h
+++ b/src/THaAnalyzer.h
@@ -74,6 +74,9 @@ public:
   void           SetMarkInterval( UInt_t interval ) { fMarkInterval = interval; }
   void           SetVerbosity( Int_t level )        { fVerbose = level; }
 
+  // Set the EPICS event type
+  void           SetEpicsEvtType(Int_t itype);
+
   static THaAnalyzer* GetInstance() { return fgAnalyzer; }
 
   // Return codes for analysis routines inside event loop

--- a/src/THaEpicsEvtHandler.C
+++ b/src/THaEpicsEvtHandler.C
@@ -102,7 +102,8 @@ THaAnalysisObject::EStatus THaEpicsEvtHandler::Init(const TDatime& date)
 
   cout << "Howdy !  We are initializing THaEpicsEvtHandler !!   name =   "<<fName<<endl;
 
-  eventtypes.push_back(131);  // what events to look for
+// Set the event type to the default unless the client has already defined it.
+  if (GetNumTypes()==0) SetEvtType(Decoder::EPICS_EVTYPE); 
 
   fStatus = kOK;
   return kOK;

--- a/src/THaEvtTypeHandler.C
+++ b/src/THaEvtTypeHandler.C
@@ -28,6 +28,16 @@ THaEvtTypeHandler::~THaEvtTypeHandler()
   }
 }
 
+void THaEvtTypeHandler::AddEvtType(int evtype) {
+  eventtypes.push_back(evtype);
+}
+  
+void THaEvtTypeHandler::SetEvtType(int evtype) {
+  eventtypes.clear();
+  AddEvtType(evtype);
+}
+
+
 void THaEvtTypeHandler::EvPrint() const
 {
   cout << "Hello !  THaEvtTypeHandler name =  "<<GetName()<<endl;

--- a/src/THaEvtTypeHandler.h
+++ b/src/THaEvtTypeHandler.h
@@ -27,6 +27,14 @@ public:
    virtual void EvDump(THaEvData *evdata) const;
    virtual void SetDebugFile(std::ofstream *file) { if (file!=0) fDebugFile=file; };
    virtual void SetDebugFile(const char *filename);
+   virtual void AddEvtType(int evtype);
+   virtual void SetEvtType(int evtype);
+   virtual Int_t GetNumTypes() { return eventtypes.size(); };
+   virtual Int_t GetEvtType() {
+     if (eventtypes.size()==0) return -1;
+     return eventtypes[0];
+   }
+   virtual std::vector<Int_t> GetEvtTypes() { return eventtypes; };
 
 protected:
 

--- a/src/THaOutput.C
+++ b/src/THaOutput.C
@@ -416,12 +416,6 @@ void THaOutput::BuildList( const vector<string>& vdata)
       if (CmpNoCase(vdata[1],"epics") == 0) fOpenEpics = kFALSE;
     }
     if (fOpenEpics) {
-       cout << "THaOutput::ERROR: Syntax error in output.def"<<endl;
-       cout << "Must 'begin' and 'end' before 'begin' again."<<endl;
-       cout << "e.g. 'begin epics' ..... 'end epics'"<<endl;
-       return ;
-    }
-    if (fOpenEpics) {
        if (fFirstEpics) {
            if (!fEpicsTree)
               fEpicsTree = new TTree("E","Hall A Epics Data");


### PR DESCRIPTION
This little pull request solves two small problems. 
1. The problem noticed by Kijun where hall C uses event type 180 for their  EPICS events (instead of type 131).  Now there is a new public method   for THaAnalyzer, so the user can do this :  analyzer->SetEpicsEventType(180);
Default is still 131, but when setting to 180 it will look for that instead.  All other functionality remains the same.
2. The problem noticed by Ed Brash that the 17th bit of Fastbus TDCs  (for leading/trailing edge info) is not presented on the public interface.   There are new methods in THaEvData::GetLEbit and GetOpt which get  the "Opt" bit.  They are redundant as they do the same thing. Of course, the option to obtain the raw data word (GetRawData) and  then get whatever bit you want had already existed.
