### PR TITLE
Per request of Steve Wood, add a  GetRawDataBuffer() method to ThaEvD…

### DIFF
--- a/hana_decode/THaEvData.h
+++ b/hana_decode/THaEvData.h
@@ -31,6 +31,9 @@ public:
   // Load CODA data evbuffer. Derived classes MUST implement this function.
   virtual Int_t LoadEvent(const UInt_t* evbuffer) = 0;
 
+// return a pointer to a full event
+  const UInt_t* GetRawDataBuffer() const { return buffer;}  
+
   virtual Bool_t IsMultiBlockMode() { return fMultiBlockMode; };
   virtual Bool_t BlockIsDone() { return fBlockIsDone; };
 


### PR DESCRIPTION
…ata to return a pointer to a full event

Code to illustrate how to use the new method
      // Test ability to extract buffer
      const UInt_t *evbuff;
 
      evbuff = evdata->GetRawDataBuffer();
 
      Int_t len=evbuff[0]+1;
      for (Int_t j=0; j<len; j++) {
        cout << "evbuffer["<<dec<<j<<"] =  0x"<<hex<<evbuff[j]<<"   = "<<dec<<evbuff[j]<<endl;
      }
