### PR TITLE
Decoders for CAEN 775 TDC and CAEN 792 ADC

### DIFF
--- a/SConscript.py
+++ b/SConscript.py
@@ -20,7 +20,7 @@ hana_decode/Lecroy1881Module.h hana_decode/Lecroy1875Module.h
 hana_decode/Fadc250Module.h hana_decode/GenScaler.h hana_decode/Scaler560.h
 hana_decode/Scaler1151.h hana_decode/Scaler3800.h hana_decode/Scaler3801.h
 hana_decode/F1TDCModule.h hana_decode/Caen1190Module.h
-hana_decode/Caen775Module.h
+hana_decode/Caen775Module.h hana_decode/Caen792Module.h
 hana_decode/SkeletonModule.h
 hana_decode/THaBenchmark.h hana_decode/haDecode_LinkDef.h
 """)

--- a/SConscript.py
+++ b/SConscript.py
@@ -20,6 +20,7 @@ hana_decode/Lecroy1881Module.h hana_decode/Lecroy1875Module.h
 hana_decode/Fadc250Module.h hana_decode/GenScaler.h hana_decode/Scaler560.h
 hana_decode/Scaler1151.h hana_decode/Scaler3800.h hana_decode/Scaler3801.h
 hana_decode/F1TDCModule.h hana_decode/Caen1190Module.h
+hana_decode/Caen775Module.h
 hana_decode/SkeletonModule.h
 hana_decode/THaBenchmark.h hana_decode/haDecode_LinkDef.h
 """)

--- a/hana_decode/Caen775Module.C
+++ b/hana_decode/Caen775Module.C
@@ -48,6 +48,7 @@ void Caen775Module::Init() {
   Clear();
   IsInit = kTRUE;
   fName = "Caen TDC 775 Module";
+  strcpy(fModType,"tdc");
 }
 
 Int_t Caen775Module::LoadSlot(THaSlotData *sldat, const UInt_t* evbuffer, const UInt_t *pstop) {
@@ -62,7 +63,7 @@ Int_t Caen775Module::LoadSlot(THaSlotData *sldat, const UInt_t* evbuffer, const 
        ++p;
        UInt_t chan=((*p)&0x00ff0000)>>16;
        UInt_t raw=((*p)&0x00000fff);
-       Int_t status = sldat->loadData("adc",chan,raw,raw);
+       Int_t status = sldat->loadData(fModType,chan,raw,raw);
        fWordsSeen++;
        if (chan < fData.size()) fData[chan]=raw;
 //       cout << "word   "<<i<<"   "<<chan<<"   "<<raw<<endl;
@@ -97,7 +98,7 @@ Int_t Caen775Module::LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer, Int_t 
     } else if (fWordsSeen <= nword) { // excludes the End of Block (EOB) word
       UInt_t chan=((p[index])&0x00ff0000)>>16; // number of channel which data are coming from bits 16-20
       UInt_t raw=((p[index])&0x00000fff);      // raw datum bits 0-11
-      Int_t status = sldat->loadData("tdc",chan,raw,raw);
+      Int_t status = sldat->loadData(fModType,chan,raw,raw);
       fWordsSeen++;
       counter++;
       if (chan < fData.size()) fData[chan]=raw;

--- a/hana_decode/Caen775Module.h
+++ b/hana_decode/Caen775Module.h
@@ -30,6 +30,9 @@ public:
    virtual Int_t LoadSlot(THaSlotData *sldat,  const UInt_t *evbuffer, const UInt_t *pstop );
    virtual Int_t LoadSlot(THaSlotData *sldat, const UInt_t* evbuffer, Int_t pos, Int_t len);
 
+protected:
+   char fModType[4];
+
 private:
 
    static const size_t NTDCCHAN = 32;

--- a/hana_decode/Caen792Module.C
+++ b/hana_decode/Caen792Module.C
@@ -1,0 +1,35 @@
+/////////////////////////////////////////////////////////////////////
+//
+//   Caen792Module
+//   author Stephen Wood
+//   author Vincent Sulkosky
+//   
+//   Currently assume decoding is identical to the 775
+//
+/////////////////////////////////////////////////////////////////////
+
+#include "Caen792Module.h"
+#include <iostream>
+
+using namespace std;
+
+namespace Decoder {
+
+  Module::TypeIter_t Caen792Module::fgThisType =
+    DoRegister( ModuleType( "Decoder::Caen792Module" , 792 ));
+
+  Caen792Module::Caen792Module(Int_t crate, Int_t slot) : Caen775Module(crate, slot) {
+    fDebugFile=0;
+    Init();
+    fName = "Caen ADC 792 Module";
+  }
+
+  void Caen792Module::Init() {
+    cout << endl << "Initializing v792 using v775 decoder";
+    Caen775Module::Init();
+    strcpy(fModType,"adc");
+  }
+  
+}
+    
+ClassImp(Decoder::Caen792Module)

--- a/hana_decode/Caen792Module.h
+++ b/hana_decode/Caen792Module.h
@@ -1,0 +1,33 @@
+#ifndef Caen792Module_
+#define Caen792Module_
+
+/////////////////////////////////////////////////////////////////////
+//
+//   Caen792Module
+//   Single Hit ADC
+//
+/////////////////////////////////////////////////////////////////////
+
+#include "Caen775Module.h"
+
+namespace Decoder {
+
+  class Caen792Module : public Caen775Module {
+
+  public:
+
+    Caen792Module() {};
+    Caen792Module(Int_t crate, Int_t slot);
+    virtual void Init();
+
+  private:
+
+    static TypeIter_t fgThisType;
+
+    ClassDef(Caen792Module,0)  //  Caen792 module
+
+  };
+
+}
+
+#endif

--- a/hana_decode/Decoder.h
+++ b/hana_decode/Decoder.h
@@ -35,7 +35,7 @@ namespace Decoder {
 
   static const Int_t MAXROC = 32;
   static const Int_t MAXBANK = 4095;
-  static const Int_t MAXSLOT = 30;
+  static const Int_t MAXSLOT = 32;
   static const Int_t MAXSLOT_FB = 26;
 
   static const Int_t MAX_PHYS_EVTYPE  = 14;  // Types up to this are physics

--- a/hana_decode/Makefile
+++ b/hana_decode/Makefile
@@ -169,7 +169,7 @@ SRC = THaUsrstrutils.C THaCrateMap.C THaCodaData.C \
       Lecroy1877Module.C Lecroy1881Module.C Lecroy1875Module.C \
       Fadc250Module.C GenScaler.C Scaler560.C Scaler1151.C \
       Scaler3800.C Scaler3801.C F1TDCModule.C Caen1190Module.C \
-      Caen775Module.C \
+      Caen775Module.C Caen792Module.C \
       SkeletonModule.C
 
 ifndef STANDALONE

--- a/hana_decode/Makefile
+++ b/hana_decode/Makefile
@@ -169,6 +169,7 @@ SRC = THaUsrstrutils.C THaCrateMap.C THaCodaData.C \
       Lecroy1877Module.C Lecroy1881Module.C Lecroy1875Module.C \
       Fadc250Module.C GenScaler.C Scaler560.C Scaler1151.C \
       Scaler3800.C Scaler3801.C F1TDCModule.C Caen1190Module.C \
+      Caen775Module.C \
       SkeletonModule.C
 
 ifndef STANDALONE

--- a/hana_decode/SConscript.py
+++ b/hana_decode/SConscript.py
@@ -23,6 +23,7 @@ CodaDecoder.C Module.C VmeModule.C PipeliningModule.C FastbusModule.C
 Lecroy1877Module.C Lecroy1881Module.C Lecroy1875Module.C
 Fadc250Module.C GenScaler.C Scaler560.C Scaler1151.C
 Scaler3800.C Scaler3801.C F1TDCModule.C Caen1190Module.C
+Caen775Module.C
 SkeletonModule.C
 """)
 #evio.C

--- a/hana_decode/SConscript.py
+++ b/hana_decode/SConscript.py
@@ -23,7 +23,7 @@ CodaDecoder.C Module.C VmeModule.C PipeliningModule.C FastbusModule.C
 Lecroy1877Module.C Lecroy1881Module.C Lecroy1875Module.C
 Fadc250Module.C GenScaler.C Scaler560.C Scaler1151.C
 Scaler3800.C Scaler3801.C F1TDCModule.C Caen1190Module.C
-Caen775Module.C
+Caen775Module.C Caen792Module.C
 SkeletonModule.C
 """)
 #evio.C

--- a/hana_decode/haDecode_LinkDef.h
+++ b/hana_decode/haDecode_LinkDef.h
@@ -23,6 +23,7 @@
 #pragma link C++ class Decoder::Fadc250Module+;
 #pragma link C++ class Decoder::F1TDCModule+;
 #pragma link C++ class Decoder::Caen1190Module+;
+#pragma link C++ class Decoder::Caen775Module+;
 #pragma link C++ class Decoder::SkeletonModule+;
 #pragma link C++ class Decoder::THaCodaData+;
 #pragma link C++ class Decoder::THaCodaFile+;

--- a/hana_decode/haDecode_LinkDef.h
+++ b/hana_decode/haDecode_LinkDef.h
@@ -24,6 +24,7 @@
 #pragma link C++ class Decoder::F1TDCModule+;
 #pragma link C++ class Decoder::Caen1190Module+;
 #pragma link C++ class Decoder::Caen775Module+;
+#pragma link C++ class Decoder::Caen792Module+;
 #pragma link C++ class Decoder::SkeletonModule+;
 #pragma link C++ class Decoder::THaCodaData+;
 #pragma link C++ class Decoder::THaCodaFile+;


### PR DESCRIPTION
Tested minimally.  Works with a single 792 with it's data wrapped in a bank.

Also changed MAXSLOT to 32 because 31 is a valid slot ID for these CAEN modules.
