### PR TITLE
minor BPM changes,addition of a calibration offset.

### DIFF
--- a/src/THaBPM.C
+++ b/src/THaBPM.C
@@ -72,12 +72,12 @@ Int_t THaBPM::ReadDatabase( const TDatime& date )
   if( !err ) {
     memset( pedestals, 0, sizeof(pedestals) );
     memset( rotations, 0, sizeof(rotations) );
-	memset( offsets	 , 0, sizeof( offsets ) );
+    memset( offsets  , 0, sizeof( offsets ) );
     DBRequest calib_request[] = {
       { "calib_rot",   &fCalibRot },
       { "pedestals",   pedestals, kDouble, NCHAN, 1 },
       { "rotmatrix",   rotations, kDouble, NCHAN, 1 },
-	  { "offsets"  ,   offsets,   kDouble, 2    , 1 },
+      { "offsets"  ,   offsets,   kDouble, 2    , 1 },
       { 0 }
     };
     err = LoadDB( file, date, calib_request, fPrefix );
@@ -86,8 +86,8 @@ Int_t THaBPM::ReadDatabase( const TDatime& date )
   if( err )
     return err;
 
-	fOffset(0) = offsets[0];
-	fOffset(1) = offsets[1];
+  fOffset(0) = offsets[0];
+  fOffset(1) = offsets[1];
 
   fPedestals.SetElements( pedestals );
   fRot2HCSPos(0,0) = rotations[0];

--- a/src/THaBPM.C
+++ b/src/THaBPM.C
@@ -44,7 +44,7 @@ Int_t THaBPM::ReadDatabase( const TDatime& date )
   const char* const here = "ReadDatabase";
 
   vector<Int_t> detmap;
-  Double_t pedestals[NCHAN], rotations[NCHAN], offsets[2]={0};
+  Double_t pedestals[NCHAN], rotations[NCHAN], offsets[2];
 
   FILE* file = OpenFile( date );
   if( !file )
@@ -72,6 +72,7 @@ Int_t THaBPM::ReadDatabase( const TDatime& date )
   if( !err ) {
     memset( pedestals, 0, sizeof(pedestals) );
     memset( rotations, 0, sizeof(rotations) );
+	memset( offsets	 , 0, sizeof( offsets ) );
     DBRequest calib_request[] = {
       { "calib_rot",   &fCalibRot },
       { "pedestals",   pedestals, kDouble, NCHAN, 1 },

--- a/src/THaBPM.C
+++ b/src/THaBPM.C
@@ -27,7 +27,7 @@ using namespace std;
 THaBPM::THaBPM( const char* name, const char* description,
 				  THaApparatus* apparatus ) :
   THaBeamDet(name,description,apparatus),
-  fRawSignal(NCHAN),fPedestals(NCHAN),fCorSignal(NCHAN),fRotPos(NCHAN),
+  fRawSignal(NCHAN),fPedestals(NCHAN),fCorSignal(NCHAN),fRotPos(NCHAN/2),
   fRot2HCSPos(NCHAN/2,NCHAN/2)
 {
   // Constructor
@@ -44,7 +44,7 @@ Int_t THaBPM::ReadDatabase( const TDatime& date )
   const char* const here = "ReadDatabase";
 
   vector<Int_t> detmap;
-  Double_t pedestals[NCHAN], rotations[NCHAN];
+  Double_t pedestals[NCHAN], rotations[NCHAN], offsets[2]={0};
 
   FILE* file = OpenFile( date );
   if( !file )
@@ -76,6 +76,7 @@ Int_t THaBPM::ReadDatabase( const TDatime& date )
       { "calib_rot",   &fCalibRot },
       { "pedestals",   pedestals, kDouble, NCHAN, 1 },
       { "rotmatrix",   rotations, kDouble, NCHAN, 1 },
+	  { "offsets"  ,   offsets,   kDouble, 2    , 1 },
       { 0 }
     };
     err = LoadDB( file, date, calib_request, fPrefix );
@@ -83,6 +84,9 @@ Int_t THaBPM::ReadDatabase( const TDatime& date )
   fclose(file);
   if( err )
     return err;
+
+	fOffset(0) = offsets[0];
+	fOffset(1) = offsets[1];
 
   fPedestals.SetElements( pedestals );
   fRot2HCSPos(0,0) = rotations[0];


### PR DESCRIPTION
Added offsets in the ReadDataBase function. The Offsets are calibration constants that allow for calibration of the BPM to the Harp. The size of the offsets array is set to 2 and those two elements are set to zero unless read from a database. 

Fixed the size of fRotPos from NCAN to NCAN/2.  fRotPos needs to be a two element vector because it is used in a multiplication operation with a 2x2 matrix.  