### PR TITLE
Coda file search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ ChangeLog
 # Editor lint
 .#*
 *~
+*.sw?
 
 # Helpers
 /fix-filedates.sh

--- a/src/THaRun.C
+++ b/src/THaRun.C
@@ -69,37 +69,6 @@ THaRun::THaRun(
 }
 
 //_____________________________________________________________________________
-THaRun::THaRun(
-    const char** pathList,
-    const TString filename,
-    const char* description
-  ) : THaCodaRun(description), fMaxScan(fgMaxScan)
-{
-  struct stat buffer;
-  const char** path = pathList;
-
-  int i=0;
-  fFilename="";
-
-  cout << "Looking for file:\n";
-  while(path && *path ) {
-    fFilename = Form( "%s/%s", *path, filename.Data() );
-    cout << "\t'" << fFilename << "'" << endl;
-
-    if( stat (fFilename.Data(), &buffer) == 0 ) break;
-    path++;
-    if( ++i>100 ) break;  // safety hatch
-  }
-  cout << endl << "--> Opening file:  " << fFilename << endl;
-
-  fCodaData = new THaCodaFile;  //Specifying the file name would open the file
-  FindSegmentNumber();
-
-  // Hall A runs normally contain all these items
-  fDataRequired = kDate|kRunNumber|kRunType|kPrescales;
-}
-
-//_____________________________________________________________________________
 THaRun::THaRun( const THaRun& rhs ) :
   THaCodaRun(rhs), fFilename(rhs.fFilename), fMaxScan(rhs.fMaxScan)
 {

--- a/src/THaRun.C
+++ b/src/THaRun.C
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <cassert>
 #include <sys/stat.h>
+#include <vector>
 
 using namespace std;
 using namespace Decoder;
@@ -32,6 +33,33 @@ THaRun::THaRun( const char* fname, const char* description ) :
   THaCodaRun(description), fFilename(fname), fMaxScan(fgMaxScan)
 {
   // Normal & default constructor
+
+  fCodaData = new THaCodaFile;  //Specifying the file name would open the file
+  FindSegmentNumber();
+
+  // Hall A runs normally contain all these items
+  fDataRequired = kDate|kRunNumber|kRunType|kPrescales;
+}
+
+//_____________________________________________________________________________
+THaRun::THaRun(
+    std::vector<TString> pathList,
+    const TString filename,
+    const char* description
+  ) : THaCodaRun(description), fMaxScan(fgMaxScan)
+{
+  struct stat buffer;
+
+  fFilename="";
+
+  cout << "Looking for file:\n";
+  for(vector<TString>::size_type i=0; i<pathList.size(); i++) {
+    fFilename = Form( "%s/%s", pathList[i].Data(), filename.Data() );
+    cout << "\t'" << fFilename << "'" << endl;
+
+    if( stat (fFilename.Data(), &buffer) == 0 ) break;
+  }
+  cout << endl << "--> Opening file:  " << fFilename << endl;
 
   fCodaData = new THaCodaFile;  //Specifying the file name would open the file
   FindSegmentNumber();

--- a/src/THaRun.C
+++ b/src/THaRun.C
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <cstdlib>
 #include <cassert>
+#include <sys/stat.h>
 
 using namespace std;
 using namespace Decoder;
@@ -31,6 +32,37 @@ THaRun::THaRun( const char* fname, const char* description ) :
   THaCodaRun(description), fFilename(fname), fMaxScan(fgMaxScan)
 {
   // Normal & default constructor
+
+  fCodaData = new THaCodaFile;  //Specifying the file name would open the file
+  FindSegmentNumber();
+
+  // Hall A runs normally contain all these items
+  fDataRequired = kDate|kRunNumber|kRunType|kPrescales;
+}
+
+//_____________________________________________________________________________
+THaRun::THaRun(
+    const char** pathList,
+    const TString filename,
+    const char* description
+  ) : THaCodaRun(description), fMaxScan(fgMaxScan)
+{
+  struct stat buffer;
+  const char** path = pathList;
+
+  int i=0;
+  fFilename="";
+
+  cout << "Looking for file:\n";
+  while(path && *path ) {
+    fFilename = Form( "%s/%s", *path, filename.Data() );
+    cout << "\t'" << fFilename << "'" << endl;
+
+    if( stat (fFilename.Data(), &buffer) == 0 ) break;
+    path++;
+    if( ++i>100 ) break;  // safety hatch
+  }
+  cout << endl << "--> Opening file:  " << fFilename << endl;
 
   fCodaData = new THaCodaFile;  //Specifying the file name would open the file
   FindSegmentNumber();

--- a/src/THaRun.h
+++ b/src/THaRun.h
@@ -15,6 +15,7 @@ class THaRun : public THaCodaRun {
 public:
   THaRun( const char* filename="", const char* description="" );
   THaRun( const THaRun& run );
+  THaRun( const char** pathList, const TString filename, const char* description="" );
   virtual THaRun& operator=( const THaRunBase& rhs );
   virtual ~THaRun();
 

--- a/src/THaRun.h
+++ b/src/THaRun.h
@@ -16,7 +16,6 @@ public:
   THaRun( const char* filename="", const char* description="" );
   THaRun( const THaRun& run );
   THaRun( std::vector<TString> pathList, const TString filename, const char* description="" );
-  THaRun( const char** pathList, const TString filename, const char* description="" );
   virtual THaRun& operator=( const THaRunBase& rhs );
   virtual ~THaRun();
 

--- a/src/THaRun.h
+++ b/src/THaRun.h
@@ -15,6 +15,7 @@ class THaRun : public THaCodaRun {
 public:
   THaRun( const char* filename="", const char* description="" );
   THaRun( const THaRun& run );
+  THaRun( std::vector<TString> pathList, const TString filename, const char* description="" );
   THaRun( const char** pathList, const TString filename, const char* description="" );
   virtual THaRun& operator=( const THaRunBase& rhs );
   virtual ~THaRun();


### PR DESCRIPTION
Add new THaRun constructor that can find a file in a path list
- Allow for THaRun to search a set of paths for a filename.  First hit wins.

- Calling example in a replay script:
```
  const char* pathList[] = {
    ".",
    "./raw",
    "./cache",
    NULL  // The NULL *must* be present here.  Do not delete
  };
  const char* RunFileNamePattern = "shms_all_%05d.dat";
  THaRun* run = new THaRun( pathList, RunFileNamePattern, RunNumber);
```

- I would set './raw' and './cache' as symlinks to the relevant local path on the Hall cluster and the /cache/mss/hallX/... path, respectively.
