### PR TITLE
Explicitely list output file for wget

### DIFF
--- a/evio/Makefile
+++ b/evio/Makefile
@@ -44,7 +44,7 @@ else
 	$(shell $(CURL) $(URL) -o $(TAR))
 endif
 else
-	$(shell $(WGET) $(URL))
+	$(shell $(WGET) $(URL) -O $(TAR))
 endif
 
 install: all


### PR DESCRIPTION
The wget on one of the ifarm machines drops the .tar.gz so the downloaded file doesn't get the expected name.