### PR TITLE
Catch overflows in high rate scalers.

### DIFF
--- a/hana_decode/Caen775Module.C
+++ b/hana_decode/Caen775Module.C
@@ -131,7 +131,8 @@ Int_t Caen775Module::LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer, Int_t 
   return fWordsSeen;
 }
 
-Int_t Caen775Module::GetData(Int_t chan) const {
+  /* Does anything use this method */
+UInt_t Caen775Module::GetData(Int_t chan) const {
   if (chan < 0 || chan > fNumChan) return 0;
   return fData[chan];
 }

--- a/hana_decode/Caen775Module.h
+++ b/hana_decode/Caen775Module.h
@@ -23,7 +23,7 @@ public:
    using Module::GetData;
    using Module::LoadSlot;
 
-   virtual Int_t GetData(Int_t chan) const;
+   virtual UInt_t GetData(Int_t chan) const;
    virtual void Init();
    virtual void Clear(const Option_t *opt="");
    virtual Int_t Decode(const UInt_t*) { return 0; }

--- a/hana_decode/GenScaler.h
+++ b/hana_decode/GenScaler.h
@@ -25,7 +25,7 @@ namespace Decoder {
 
     virtual void  Clear(const Option_t* opt="");
     virtual Int_t Decode(const UInt_t *evbuffer);
-    virtual Int_t GetData(Int_t chan) const;   // Raw scaler counts
+    virtual UInt_t GetData(Int_t chan) const;   // Raw scaler counts
     virtual Bool_t IsSlot(UInt_t rdata);
     virtual void DoPrint() const;
 
@@ -50,7 +50,7 @@ namespace Decoder {
     void LoadRates();
     Bool_t checkchan(Int_t chan) const { return (chan >=0 && chan < fWordsExpect); }
     Bool_t fIsDecoded, fFirstTime, fDeltaT;
-    Int_t *fDataArray, *fPrevData;
+    UInt_t *fDataArray, *fPrevData;
     Double_t *fRate;
     Int_t fClockChan, fNumChanMask, fNumChanShift;
     Bool_t fHasClock;

--- a/hana_decode/Module.h
+++ b/hana_decode/Module.h
@@ -44,7 +44,7 @@ namespace Decoder {
     virtual void SetFirmware(Int_t fw) {fFirmwareVers=fw;};
 
     // inheriting classes need to implement one or more of these
-    virtual Int_t GetData(Int_t) const { return 0; };
+    virtual UInt_t GetData(Int_t) const { return 0; };
     virtual Int_t GetData(Int_t, Int_t) const { return 0; };
     virtual Int_t GetData(Int_t, Int_t, Int_t) const { return 0; };
     virtual Int_t GetData(Decoder::EModuleType,


### PR DESCRIPTION
  Several changes in the OO decoder are made to deal with scalers that
  could overflow.
1.  Since the hardware scalers we use are 32 bits, the GetData(Int_t) method
  of GenScaler has been changed to return UInt_t instead of Int_t.
  Note though, the base definition of GetData(Int_t) is in Module.h, so that
  is where it is changed.  This might impact classes for other hardware, but
  the only other classes that have GetData(Int_t) are Caen775Module and
  Caen792Module, so GetData(Int_t) was changed in Caen775Module.{Ch} too.  It
  appears that nothing actually uses this method for the Caen modules, so
  perhaps it should be removed.
2.  In computing the time difference between successive scaler reads in
  GenScaler, a check is made overflow so that we won't get a huge negative
  time when the reference clock overflows.
3.  In computing rates, a check is made so that an overflow won't result in
  a huge negative rate.