### PR TITLE
Pipelining fix1

### DIFF
--- a/hana_decode/Fadc250Module.C
+++ b/hana_decode/Fadc250Module.C
@@ -79,11 +79,11 @@ namespace Decoder {
     DoRegister( ModuleType( "Decoder::Fadc250Module" , 250 ));
 
   Fadc250Module::Fadc250Module()
-    : PipeliningModule(), fPulseData(NADCCHAN), data_type_def(15)
+    : PipeliningModule(), fPulseData(NADCCHAN)
   { memset(&fadc_data, 0, sizeof(fadc_data)); }
 
   Fadc250Module::Fadc250Module(Int_t crate, Int_t slot)
-    : PipeliningModule(crate, slot), fPulseData(NADCCHAN), data_type_def(15)
+    : PipeliningModule(crate, slot), fPulseData(NADCCHAN)
   {
     memset(&fadc_data, 0, sizeof(fadc_data));
     IsInit = kFALSE;

--- a/hana_decode/Fadc250Module.C
+++ b/hana_decode/Fadc250Module.C
@@ -79,11 +79,11 @@ namespace Decoder {
     DoRegister( ModuleType( "Decoder::Fadc250Module" , 250 ));
 
   Fadc250Module::Fadc250Module()
-    : PipeliningModule(), fPulseData(NADCCHAN), data_type_def(0)
+    : PipeliningModule(), fPulseData(NADCCHAN), data_type_def(15)
   { memset(&fadc_data, 0, sizeof(fadc_data)); }
 
   Fadc250Module::Fadc250Module(Int_t crate, Int_t slot)
-    : PipeliningModule(crate, slot), fPulseData(NADCCHAN), data_type_def(0)
+    : PipeliningModule(crate, slot), fPulseData(NADCCHAN), data_type_def(15)
   {
     memset(&fadc_data, 0, sizeof(fadc_data));
     IsInit = kFALSE;
@@ -133,9 +133,12 @@ namespace Decoder {
     // Clear event-by-event data
     VmeModule::Clear(opt);
     ClearDataVectors();
+    // Initialize data_type_def to FILLER and data types to false
+    data_type_def = 15;
     // Initialize data types to false
     data_type_4 = data_type_6 = data_type_7 = data_type_8 = data_type_9 = data_type_10 = false;
     block_header_found = block_trailer_found = event_header_found = slots_match = false;
+
   }
 
   void Fadc250Module::Init() {

--- a/hana_decode/Fadc250Module.h
+++ b/hana_decode/Fadc250Module.h
@@ -108,7 +108,6 @@ namespace Decoder {
 
     Bool_t data_type_4, data_type_6, data_type_7, data_type_8, data_type_9, data_type_10;
     Bool_t block_header_found, block_trailer_found, event_header_found, slots_match;
-    uint32_t data_type_def;
 
     void ClearDataVectors();
     void PopulateDataVector(std::vector<uint32_t>& data_vector, uint32_t data);

--- a/hana_decode/PipeliningModule.C
+++ b/hana_decode/PipeliningModule.C
@@ -21,13 +21,14 @@ namespace Decoder {
      fFirstTime = kTRUE;
      fBlockHeader = 0;
      fNWarnings = 0;
+     data_type_def = 15;  /* initialize to FILLER WORD */
      ReStart();
 }
 
 PipeliningModule::~PipeliningModule() {
 }
 
-Int_t PipeliningModule::SplitBuffer(std::vector< UInt_t > codabuffer ) {
+Int_t PipeliningModule::SplitBuffer(const std::vector< UInt_t >& codabuffer) {
 
 // Split a CODA buffer into blocks.   A block is data from a traditional physics event.
 // In MultiBlock Mode, a pipelining module can have several events in each CODA buffer.

--- a/hana_decode/PipeliningModule.C
+++ b/hana_decode/PipeliningModule.C
@@ -67,7 +67,6 @@ Int_t PipeliningModule::SplitBuffer(const std::vector< UInt_t >& codabuffer) {
     }
 
     UInt_t data_type_id = (data >> 31) & 0x1;  // Data type identification, mask 1 bit
-    static UInt_t data_type_def;               // Data type defining words, mask 4 bits
 
     if (data_type_id == 1)
       data_type_def = (data >> 27) & 0xF;

--- a/hana_decode/PipeliningModule.h
+++ b/hana_decode/PipeliningModule.h
@@ -44,13 +44,14 @@ public:
 
 protected:
 
-   Int_t SplitBuffer(std::vector< UInt_t > bigbuffer);
+   Int_t SplitBuffer(const std::vector< UInt_t >& bigbuffer);
    void ReStart();
    std::vector< UInt_t >GetNextBlock();
    Int_t LoadNextEvBuffer(THaSlotData *sldat)=0;
    virtual Int_t LoadThisBlock(THaSlotData *sldat, std::vector<UInt_t > evb)=0;
    Int_t fNWarnings;
    UInt_t fBlockHeader;
+   UInt_t data_type_def;
 
    Bool_t fFirstTime;
 
@@ -60,6 +61,8 @@ protected:
 
 private:
 
+   PipeliningModule(const PipeliningModule &fh);
+   PipeliningModule& operator=(const PipeliningModule &fh);
    ClassDef(Decoder::PipeliningModule,0)  // A pipelining module
 
 };


### PR DESCRIPTION
Fixes that address the original issue #151 (data_type_def not necessarily defined) and the related discussion about why data_type_def was static (should not be), and about the need to pass the data buffer as a constant reference in SplitBuffer.  All pretty easy to fix, but it took me awhile to test it because my test stand had been upgraded to CODA 3.07, which opened up a whole other can of worms.