### PR TITLE
Some hana_decode changes to allow ADC trigger time slippage correction

### DIFF
--- a/hana_decode/Fadc250Module.C
+++ b/hana_decode/Fadc250Module.C
@@ -70,8 +70,8 @@
 
 using namespace std;
 
-//#define DEBUG
-//#define WITH_DEBUG
+// #define DEBUG
+// #define WITH_DEBUG
 
 namespace Decoder {
 
@@ -138,7 +138,6 @@ namespace Decoder {
     // Initialize data types to false
     data_type_4 = data_type_6 = data_type_7 = data_type_8 = data_type_9 = data_type_10 = false;
     block_header_found = block_trailer_found = event_header_found = slots_match = false;
-
   }
 
   void Fadc250Module::Init() {
@@ -439,6 +438,16 @@ namespace Decoder {
     }
   }
 
+  Int_t Fadc250Module::GetTriggerTime() const {
+    // Truncate to 32 bits
+    Int_t shorttime=fadc_data.trig_time;
+    return shorttime;
+#ifdef WITH_DEBUG
+    if (fDebugFile != 0)
+      *fDebugFile << "Fadc250Module::GetTriggerTime = "
+      << fadc_data.trig_time << " " << stime << endl;
+#endif	
+  }
   
   Int_t Fadc250Module::GetPulseSamplesData(Int_t chan, Int_t ievent) const {
     Int_t nevent = 0;
@@ -634,7 +643,6 @@ namespace Decoder {
 
     SplitBuffer(evb);
     return LoadThisBlock(sldat, GetNextBlock());
-
   }
 
   Int_t Fadc250Module::LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer, Int_t pos, Int_t len) {
@@ -642,7 +650,6 @@ namespace Decoder {
     // I'm not sure we need both (historical)
 
     return LoadSlot(sldat, evbuffer+pos, evbuffer+pos+len);
-
   }
 
   void Fadc250Module::LoadTHaSlotDataObj(THaSlotData *sldat) {
@@ -685,7 +692,6 @@ namespace Decoder {
     LoadTHaSlotDataObj(sldat);
 
     return index;
-
   }
 
   Int_t Fadc250Module::DecodeOneWord(UInt_t data)

--- a/hana_decode/Fadc250Module.h
+++ b/hana_decode/Fadc250Module.h
@@ -39,6 +39,7 @@ namespace Decoder {
     virtual Int_t GetPedestalQuality(Int_t chan, Int_t ievent) const;
     virtual Int_t GetOverflowBit(Int_t chan, Int_t ievent) const;
     virtual Int_t GetUnderflowBit(Int_t chan, Int_t ievent) const;
+    virtual Int_t GetTriggerTime() const;
     virtual std::vector<uint32_t> GetPulseSamplesVector(Int_t chan) const;
     virtual Int_t GetFadcMode() const;
     virtual Int_t GetMode() const { return GetFadcMode(); };

--- a/hana_decode/Module.h
+++ b/hana_decode/Module.h
@@ -43,6 +43,8 @@ namespace Decoder {
     Bool_t BlockIsDone() { return fBlockIsDone; };
     virtual void SetFirmware(Int_t fw) {fFirmwareVers=fw;};
 
+    virtual Int_t GetTriggerTime() const {return 0;};
+
     // inheriting classes need to implement one or more of these
     virtual UInt_t GetData(Int_t) const { return 0; };
     virtual Int_t GetData(Int_t, Int_t) const { return 0; };

--- a/hana_decode/THaEvData.h
+++ b/hana_decode/THaEvData.h
@@ -183,6 +183,8 @@ public:
   UInt_t  GetInstance() const { return fInstance; }
   static UInt_t GetInstances() { return fgInstances.CountBits(); }
 
+  Decoder::THaCrateMap* GetCrateMap() const { return fMap; }
+
   Decoder::THaCrateMap* fMap;      // Pointer to active crate map
 
   // Reporting level

--- a/hana_decode/THaEvData.h
+++ b/hana_decode/THaEvData.h
@@ -100,7 +100,15 @@ public:
     }
     return module->IsMultiFunction();
   }
-
+  Int_t GetTriggerTime(Int_t crate, Int_t slot) const
+  {
+    Decoder::Module* module = GetModule(crate, slot);
+    if (!module) {
+      std::cout << "No module at crate "<<crate<<"   slot "<<slot<<std::endl;
+      return false;
+    }
+    return module->GetTriggerTime();
+  }
   Int_t GetNumEvents( Decoder::EModuleType type, Int_t crate, Int_t slot, Int_t chan) const
   {
     Decoder::Module* module = GetModule(crate, slot);


### PR DESCRIPTION
The trigger time in the header of each FADC250 module is correlates with the trigger time in the TI module, differing by a small fixed amount.  This fixed amount sometimes slips by one clock tick (4ns) and correspondingly the pulse times recorded by the ADC shift.  By monitoring the difference between the TI and FADC trigger times, this shift in pulse times can be corrected.   These commits will allow hcana to get the information it needs to make this correction.

The THaEvData::GetCrateMap is added so that hcana can search the crate map to find the slot # for each crates TI module.