### PR TITLE
Add the 4-arg version of LoadSlot.  This addresses Bug 349 in Redmine

### DIFF
--- a/hana_decode/F1TDCModule.cxx
+++ b/hana_decode/F1TDCModule.cxx
@@ -66,6 +66,10 @@ void F1TDCModule::Clear(const Option_t* opt) {
   memset(fTdcData, 0, NTDCCHAN*MAXHIT*sizeof(Int_t));
 }
 
+Int_t F1TDCModule::LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer, Int_t pos, Int_t len) {
+  return LoadSlot(sldat, evbuffer+pos, evbuffer+pos+len);
+}
+
 Int_t F1TDCModule::LoadSlot(THaSlotData *sldat, const UInt_t *evbuffer, const UInt_t *pstop) {
 // this increments evbuffer
   if (fDebugFile) *fDebugFile << "F1TDCModule:: loadslot "<<endl;

--- a/hana_decode/F1TDCModule.h
+++ b/hana_decode/F1TDCModule.h
@@ -45,6 +45,8 @@ private:
 
 // Loads sldat and increments ptr to evbuffer
    Int_t LoadSlot(THaSlotData *sldat,  const UInt_t* evbuffer, const UInt_t *pstop );
+   Int_t LoadSlot(THaSlotData *sldat,  const UInt_t* evbuffer, Int_t pos, Int_t len);
+
 
    Int_t fNumHits;
    EResolution fResol;


### PR DESCRIPTION
This fixes the problem Alexandre was noticing that bank-decoding of F1TDCModule did not work.  I'm not sure how it ever worked but maybe it was previously used in some test code that called the 3-arg version of LoadSlot explicitly.  Anyway, this fixes Bug #349 in the Redmine system.