### PR TITLE
Bankdat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ SRC          := src/THaFormula.cxx src/THaVform.cxx src/THaVhist.cxx \
 		src/THaDetMap.cxx src/THaApparatus.cxx src/THaDetector.cxx \
 		src/THaSpectrometer.cxx src/THaSpectrometerDetector.cxx \
 		src/THaHRS.cxx src/THaDecData.cxx src/BdataLoc.cxx \
-		src/THaOutput.cxx src/THaString.cxx \
+		src/THaOutput.cxx src/THaString.cxx src/BankData.cxx \
 		src/THaTrackingDetector.cxx src/THaNonTrackingDetector.cxx \
 		src/THaPidDetector.cxx src/THaSubDetector.cxx \
 		src/THaAnalysisObject.cxx src/THaDetectorBase.cxx \

--- a/hana_decode/CodaDecoder.h
+++ b/hana_decode/CodaDecoder.h
@@ -27,6 +27,8 @@ public:
   virtual Int_t GetPrescaleFactor(Int_t trigger) const;
   virtual void  SetRunTime(ULong64_t tloc);
 
+  void FillBankData(UInt_t *rdat, Int_t roc, Int_t bank, Int_t offset=0, Int_t num=1) const;
+
   Int_t FindRocs(const UInt_t *evbuffer);
   Int_t roc_decode( Int_t roc, const UInt_t* evbuffer, Int_t ipt, Int_t istop );
   Int_t bank_decode( Int_t roc, const UInt_t* evbuffer, Int_t ipt, Int_t istop );

--- a/hana_decode/THaEvData.cxx
+++ b/hana_decode/THaEvData.cxx
@@ -60,9 +60,9 @@ THaEvData::THaEvData() :
   fMap(0), first_decode(true), fTrigSupPS(true),
   fMultiBlockMode(kFALSE), fBlockIsDone(kFALSE),
   buffer(0), fDebugFile(0), run_num(0), run_type(0), fRunTime(0),
-  evt_time(0), recent_event(0),
+  evt_time(0), recent_event(0), 
   buffmode(false), synchmiss(false), synchextra(false),
-  fNSlotUsed(0), fNSlotClear(0),
+  fNSlotUsed(0), fNSlotClear(0), 
   fDoBench(kFALSE), fBench(0), fNeedInit(true), fDebug(0), fExtra(0)
 {
   fInstance = fgInstances.FirstNullBit();
@@ -72,6 +72,7 @@ THaEvData::THaEvData() :
   crateslot = new THaSlotData*[MAXROC*MAXSLOT];
   fSlotUsed  = new UShort_t[MAXROC*MAXSLOT];
   fSlotClear = new UShort_t[MAXROC*MAXSLOT];
+  memset(bankdat,0,MAXBANK*MAXROC*sizeof(BankDat_t));
   //memset(psfact,0,MAX_PSFACT*sizeof(int));
   memset(crateslot,0,MAXROC*MAXSLOT*sizeof(THaSlotData*));
   fRunTime = time(0); // default fRunTime is NOW

--- a/hana_decode/THaEvData.h
+++ b/hana_decode/THaEvData.h
@@ -36,6 +36,7 @@ public:
 
   virtual Bool_t IsMultiBlockMode() { return fMultiBlockMode; };
   virtual Bool_t BlockIsDone() { return fBlockIsDone; };
+  virtual void FillBankData(UInt_t* rdat, Int_t roc, Int_t bank, Int_t offset=0, Int_t num=1) const { return; };
 
   // Derived class to implement this
   virtual Int_t LoadFromMultiBlock() { return 0;};
@@ -231,7 +232,7 @@ protected:
   struct BankDat_t {           // Bank raw data descriptor
     Int_t pos;                 // position in evbuffer[]
     Int_t len;                 // length of data
-  } bankdat[Decoder::MAXBANK];
+  } bankdat[Decoder::MAXBANK * Decoder::MAXROC];
   Decoder::THaSlotData** crateslot;
 
   Bool_t first_decode;

--- a/hana_decode/haDecode_LinkDef.h
+++ b/hana_decode/haDecode_LinkDef.h
@@ -35,6 +35,7 @@
 #pragma link C++ class THaBenchmark+;
 #pragma link C++ class THaEvData+;
 #pragma link C++ class THaEvData::RocDat_t+;
+#pragma link C++ class THaEvData::BankDat_t+;
 
 #ifndef STANDALONE
 #pragma link C++ class Podd::MCHitInfo+;

--- a/src/BankData.cxx
+++ b/src/BankData.cxx
@@ -1,0 +1,257 @@
+//*-- Author :    Bob Michaels, April 2018
+// This is based on Ole Hansen's example UserModule
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// BankData                                                           //
+//                                                                      //
+//                                                                      //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "BankData.h"
+#include "THaAnalysisObject.h"
+#include "Varargs.h"
+#include "VarDef.h"
+#include "THaString.h"
+#include "THaVar.h"
+#include "VarType.h"
+#include "THaVarList.h"
+
+using namespace std;
+typedef string::size_type ssiz_t;
+using namespace THaString;
+
+//_____________________________________________________________________________
+BankData::BankData( const char* name, const char* description) :
+  THaPhysicsModule(name,description), Nvars(0), dvars(0), vardata(0)
+{
+  // Normal constructor. 
+
+
+}
+
+//_____________________________________________________________________________
+BankData::~BankData()
+{
+  // Destructor
+  if(dvars) delete[] dvars;
+  if(vardata) delete[] vardata;
+  RemoveVariables();
+}
+
+//_____________________________________________________________________________
+void BankData::Clear( Option_t* opt )
+{
+  // Clear all internal variables.
+
+  THaPhysicsModule::Clear(opt);
+
+  fDataValid = false;
+}
+
+//_____________________________________________________________________________
+THaAnalysisObject::EStatus BankData::Init( const TDatime& run_time )
+{
+  // Standard initialization. Calls this object's ReadDatabase(),
+  // ReadRunDatabase(), and DefineVariables()
+  // (see THaAnalysisObject::Init)
+
+  cout << "BankData init called "<<endl;
+
+  if( THaPhysicsModule::Init( run_time ) != kOK ) {
+    cout << "init not ok ?"<<endl;
+  }
+
+  fStatus = kOK;
+  return kOK;
+}
+
+//_____________________________________________________________________________
+Int_t BankData::Process( const THaEvData& evdata )
+{
+
+  if( !IsOK() ) return -1;
+
+  Int_t k=0;
+  for (UInt_t i=0; i<banklocs.size(); i++) {
+    //    cout << "BankData proc "<<dec<<i<<"  "<<banklocs[i]->roc<<"  "<<banklocs[i]->bank<<"  "<<banklocs[i]->numwords<<endl;
+   evdata.FillBankData(vardata, banklocs[i]->roc, banklocs[i]->bank, banklocs[i]->offset, banklocs[i]->numwords);
+   //   cout << "numwords "<<i<<"  "<<banklocs[i]->numwords<<endl;
+    for (Int_t j=0; j<banklocs[i]->numwords; j++) {
+      //      cout << "     data  "<<j<<"   "<<k<<"  0x"<<hex<<vardata[j]<<dec<<endl;
+      dvars[k] = 1.0*vardata[j];
+      k++;
+    }
+  }
+  //  for (Int_t i=0; i<k; i++) cout << "dvars["<<i<<"] = "<<dvars[i]<<endl;
+
+#ifdef TEST1
+  Int_t myroc=20;
+  Int_t mybank=7;
+  Int_t mydata[100];
+  cout << "BankData:: process, evnum =  "<<evdata.GetEvNum()<<"  "<<evdata.GetEvType()<<endl;
+  evdata.FillBankData(mydata,20,7,0,10);
+  for (UInt_t i=0; i<10; i++) {
+    cout << "Mydata 20, 7, 0, 10 "<<i<<"   0x"<<hex<<mydata[i]<<"   dec "<<dec<<mydata[i]<<endl;
+  }
+  cout << "-----------------------"<<endl;
+  evdata.FillBankData(mydata,20,7,5,20);
+  for (UInt_t i=0; i<20; i++) {
+    cout << "Mydata 20, 7, 5, 20 "<<i<<"   0x"<<hex<<mydata[i]<<"   dec "<<dec<<mydata[i]<<endl;
+  }
+  cout << "-----------------------"<<endl;
+  evdata.FillBankData(mydata,20,250,0,40);
+  for (UInt_t i=0; i<40; i++) {
+    cout << "Mydata 20, 250, 0, 40 "<<i<<"   0x"<<hex<<mydata[i]<<"   dec "<<dec<<mydata[i]<<endl;
+  }
+#endif
+
+  // That's it
+  fDataValid = true;
+  return 0;
+}
+
+//_____________________________________________________________________________
+Int_t BankData::ReadRunDatabase( const TDatime& date )
+{
+  // Read the parameters of this module from the run database
+
+  int ldebug=1;
+  const int LEN = 200;
+  char cbuf[LEN];
+  string::size_type minus1 = string::npos;
+  string::size_type pos1;
+  const string scomment = "#";
+  vector<string> dbline;
+  FILE *fi;
+
+  Int_t err = THaPhysicsModule::ReadRunDatabase( date );
+  if( err ) return err;
+
+  FILE* f = OpenRunDBFile( date );
+  if( !f ) return kFileError;
+
+  vector<string> fnames (GetDBFileList(GetName(), date, ""));
+ 
+  if(ldebug) cout << "fnames size "<<fnames.size()<<endl;
+
+  for (UInt_t i=0; i<fnames.size(); i++) {
+    if (ldebug) cout << "BankData:  trying database file "<<fnames[i]<<endl;
+    fi = OpenFile(fnames[i].c_str(), date);
+    if (fi != NULL) break;
+  }
+
+  if (fi == NULL) {
+    cout << "Failed to open database file for BankData"<<endl;
+    return -1;
+  }
+
+  Int_t iroc, ibank, ioff, inum;
+  std::string svar;
+
+  while( fgets(cbuf, LEN, fi) != NULL) {
+    std::string sinput(cbuf);
+    if(ldebug) cout << "database line = "<<sinput<<endl;
+    dbline = vsplit(sinput);
+    svar="";
+    if(dbline.size() > 2) {
+      pos1 = FindNoCase(dbline[0],scomment);
+      if (pos1 != minus1) continue;
+      iroc = 0;  ibank = 0; ioff = 0;  inum = 1;
+      svar = dbline[0];
+      iroc  = atoi(dbline[1].c_str());
+      ibank = atoi(dbline[2].c_str());      
+      if (dbline.size()>3) {
+          ioff = atoi(dbline[3].c_str()); 
+          if (dbline.size()>4) {
+            inum = atoi(dbline[4].c_str()); 
+	  }
+	}
+      }
+     if(svar.length()==0) continue;
+     if (ldebug) cout << "svar "<<svar<<"  len "<<svar.length()<<"  iroc "<<iroc<<"  ibank "<<ibank<<"  offset "<<ioff<<"  num "<<inum<<endl;      
+     banklocs.push_back( new BankLoc(svar, iroc, ibank, ioff, inum) );
+
+  }
+
+  cout << "banklocs size "<<banklocs.size()<<endl;
+
+// warning to myself:  do NOT call DefineVariables() here, it will lead to
+// stale global data.  Let the analyzer mechanisms call it (in the right sequence).
+
+  fStatus = kOK;
+
+  fclose(fi);
+  return fStatus;
+}
+
+//_____________________________________________________________________________
+Int_t BankData::DefineVariables( EMode mode ) {
+  // Define/delete global variables.
+  Int_t ldebug=1;
+  char svarstem[100],svarname[100],cdesc[100];
+  Nvars = 0;
+  Int_t maxwords=-999;
+  Int_t too_big = 1000000;
+  for (UInt_t i=0; i<banklocs.size(); i++) {
+      if (ldebug) cout << "bankloc "<<i<<"   "<<banklocs[i]->roc<<"   "<<banklocs[i]->bank<<"  "<<banklocs[i]->offset<<"  "<<banklocs[i]->numwords<<endl;
+      if(banklocs[i]->numwords > maxwords) maxwords = banklocs[i]->numwords;
+      Nvars += banklocs[i]->numwords;
+  }
+  // maxwords is the biggest number of words for all banklocs.
+  // dvars must be of length Nvars in order to fit all the data 
+  // for this class; it's the global data.
+  // Check that neither of these are "too_big" for some reason.
+  if (maxwords > too_big || Nvars > too_big) {
+    cerr << "BankData::ERROR:  very huge number of words "<<maxwords<<"  "<<Nvars<<endl;
+    return kInitError;
+  }
+  vardata = new UInt_t[maxwords];
+  dvars = new Double_t[Nvars];
+  for (Int_t i=0; i<Nvars; i++) dvars[i]=40+i;
+  if (!gHaVars) {
+    cerr << "BankData::ERROR: No gHaVars ?!  Well, that's a problem !!"<<endl;
+    return kInitError;
+  }
+  if (ldebug) cout << "BankData:: DefVars "<<fName<<"  "<<Nvars<<endl;
+  const Int_t* count = 0;
+  Int_t k=0;
+  for (UInt_t i = 0; i < banklocs.size(); i++) {
+    sprintf(svarname,fName);
+    strcat(svarname,".");
+    strcat(svarname,banklocs[i]->svarname.c_str());
+    sprintf(cdesc,"Bank Data ");
+    strcat(cdesc,banklocs[i]->svarname.c_str());
+    if (banklocs[i]->numwords == 1) {
+       if (ldebug) cout << "numwords = 1, svarname = "<<svarname<<endl;
+       gHaVars->DefineByType(svarname, cdesc, &dvars[k], kDouble, count);
+       k++;
+    } else {
+      for (Int_t j=0; j<banklocs[i]->numwords; j++) {
+        char cnum[100];
+        sprintf(cnum,"%d",j);
+        strcpy(svarstem,svarname);
+        strcat(svarstem,cnum);
+        if (ldebug) cout << "numwords > 1, svarname = "<<svarstem<<endl;
+        gHaVars->DefineByType(svarstem, cdesc, &dvars[k], kDouble, count);
+        k++;
+      }
+    }
+  }
+  fIsSetup = ( mode == kDefine );
+  return kOK;
+} 
+
+  
+//_____________________________________________________________________________
+void BankData::PrintInitError( const char* here )
+{
+  Error( Here(here), "Cannot set. Module already initialized." );
+}
+
+
+
+//_____________________________________________________________________________
+ClassImp(BankData)
+

--- a/src/BankData.cxx
+++ b/src/BankData.cxx
@@ -75,39 +75,13 @@ Int_t BankData::Process( const THaEvData& evdata )
 
   Int_t k=0;
   for (UInt_t i=0; i<banklocs.size(); i++) {
-    //    cout << "BankData proc "<<dec<<i<<"  "<<banklocs[i]->roc<<"  "<<banklocs[i]->bank<<"  "<<banklocs[i]->numwords<<endl;
    evdata.FillBankData(vardata, banklocs[i]->roc, banklocs[i]->bank, banklocs[i]->offset, banklocs[i]->numwords);
-   //   cout << "numwords "<<i<<"  "<<banklocs[i]->numwords<<endl;
     for (Int_t j=0; j<banklocs[i]->numwords; j++) {
-      //      cout << "     data  "<<j<<"   "<<k<<"  0x"<<hex<<vardata[j]<<dec<<endl;
       dvars[k] = 1.0*vardata[j];
       k++;
     }
   }
-  //  for (Int_t i=0; i<k; i++) cout << "dvars["<<i<<"] = "<<dvars[i]<<endl;
 
-#ifdef TEST1
-  Int_t myroc=20;
-  Int_t mybank=7;
-  Int_t mydata[100];
-  cout << "BankData:: process, evnum =  "<<evdata.GetEvNum()<<"  "<<evdata.GetEvType()<<endl;
-  evdata.FillBankData(mydata,20,7,0,10);
-  for (UInt_t i=0; i<10; i++) {
-    cout << "Mydata 20, 7, 0, 10 "<<i<<"   0x"<<hex<<mydata[i]<<"   dec "<<dec<<mydata[i]<<endl;
-  }
-  cout << "-----------------------"<<endl;
-  evdata.FillBankData(mydata,20,7,5,20);
-  for (UInt_t i=0; i<20; i++) {
-    cout << "Mydata 20, 7, 5, 20 "<<i<<"   0x"<<hex<<mydata[i]<<"   dec "<<dec<<mydata[i]<<endl;
-  }
-  cout << "-----------------------"<<endl;
-  evdata.FillBankData(mydata,20,250,0,40);
-  for (UInt_t i=0; i<40; i++) {
-    cout << "Mydata 20, 250, 0, 40 "<<i<<"   0x"<<hex<<mydata[i]<<"   dec "<<dec<<mydata[i]<<endl;
-  }
-#endif
-
-  // That's it
   fDataValid = true;
   return 0;
 }
@@ -117,7 +91,7 @@ Int_t BankData::ReadRunDatabase( const TDatime& date )
 {
   // Read the parameters of this module from the run database
 
-  int ldebug=1;
+  int ldebug=0;
   const int LEN = 200;
   char cbuf[LEN];
   string::size_type minus1 = string::npos;
@@ -126,11 +100,7 @@ Int_t BankData::ReadRunDatabase( const TDatime& date )
   vector<string> dbline;
   FILE *fi;
 
-  Int_t err = THaPhysicsModule::ReadRunDatabase( date );
-  if( err ) return err;
-
-  FILE* f = OpenRunDBFile( date );
-  if( !f ) return kFileError;
+// I don't really understand the rules for where it gets the database file
 
   vector<string> fnames (GetDBFileList(GetName(), date, ""));
  
@@ -175,10 +145,9 @@ Int_t BankData::ReadRunDatabase( const TDatime& date )
 
   }
 
-  cout << "banklocs size "<<banklocs.size()<<endl;
-
 // warning to myself:  do NOT call DefineVariables() here, it will lead to
-// stale global data.  Let the analyzer mechanisms call it (in the right sequence).
+// stale global data.  Let the analyzer mechanisms call it (in the 
+// right sequence).
 
   fStatus = kOK;
 
@@ -189,7 +158,7 @@ Int_t BankData::ReadRunDatabase( const TDatime& date )
 //_____________________________________________________________________________
 Int_t BankData::DefineVariables( EMode mode ) {
   // Define/delete global variables.
-  Int_t ldebug=1;
+  Int_t ldebug=0;
   char svarstem[100],svarname[100],cdesc[100];
   Nvars = 0;
   Int_t maxwords=-999;

--- a/src/BankData.h
+++ b/src/BankData.h
@@ -1,0 +1,62 @@
+#ifndef ROOT_BankData
+#define ROOT_BankData
+
+//////////////////////////////////////////////////////////////////////////
+//
+// BankData
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "THaPhysicsModule.h"
+#include "THaEvData.h"
+#include "TTree.h"
+#include "TNamed.h"
+#include "THaGlobals.h"
+#include "TDatime.h"
+#include "VarDef.h"
+#include <vector>
+#include <string>
+#include <cstdio>
+#include <stdarg.h>
+
+class THaTrackingModule;
+
+class BankLoc { // Utility class used by BankData
+ public:
+   BankLoc(std::string svar, Int_t iroc, Int_t ibank, Int_t ioff, Int_t inum): svarname(svar), roc(iroc), bank(ibank), offset(ioff), numwords(inum) {};
+   ~BankLoc();
+   std::string svarname;
+   Int_t roc,bank,offset,numwords;
+};
+
+class BankData : public THaPhysicsModule {
+  
+public:
+
+  BankData( const char* name, const char* description);
+  virtual ~BankData();
+  
+  virtual void  Clear( Option_t* opt="" );
+  virtual EStatus Init( const TDatime& run_time );
+  virtual Int_t   Process( const THaEvData& );
+
+protected:
+
+  virtual Int_t DefineVariables( EMode mode = kDefine );
+  virtual Int_t ReadRunDatabase( const TDatime& date );
+
+  void PrintInitError( const char* here );
+
+private:
+
+  Int_t fDebug;
+  Int_t Nvars;
+  Double_t *dvars;
+  UInt_t *vardata;
+
+  std::vector<BankLoc*> banklocs;
+
+  ClassDef(BankData,0)   // process bank data.
+};
+
+#endif

--- a/src/HallA_LinkDef.h
+++ b/src/HallA_LinkDef.h
@@ -42,6 +42,7 @@
 #pragma link C++ class WordLoc+;
 #pragma link C++ class RoclenLoc+;
 #pragma link C++ class TrigBitLoc+;
+#pragma link C++ class BankData+;
 #pragma link C++ class THaAnalysisObject+;
 #pragma link C++ class THaDetectorBase+;
 #pragma link C++ class THaPhysicsModule+;


### PR DESCRIPTION
How to use the BankData class.  
May 1, 2018    Bob Michaels

In the analysis script you need to add the module.

   gHaPhysics->Add( new BankData("BD","bank data for a roc" ));

The module will read the database in the $pwd of the analyzer.
(I'd like to put it in $DB_DIR/20180104 or whatever, but I don't 
understand the rules for how to find that yet.)

Example of a db_BD.dat file:

  # variable  crate   bank  Nskip  Nelement

  rfadc  20  250  

  skip5  20  250  5 

  xarray 20  250  8 10  

  norf   20  7  0 4

This produces global variables which can be added
to the output tree

analyzer [2] gHaVars->Print()
Collection name='THaVarList', class='THaVarList', size=23
 OBJ: THaVar	BD.rfadc	Bank Data rfadc
 OBJ: THaVar	BD.skip5	Bank Data skip5
 OBJ: THaVar	BD.xarray0	Bank Data xarray
 OBJ: THaVar	BD.xarray1	Bank Data xarray
 OBJ: THaVar	BD.xarray2	Bank Data xarray
 OBJ: THaVar	BD.xarray3	Bank Data xarray
 OBJ: THaVar	BD.xarray4	Bank Data xarray
 OBJ: THaVar	BD.xarray5	Bank Data xarray
 OBJ: THaVar	BD.xarray6	Bank Data xarray
 OBJ: THaVar	BD.xarray7	Bank Data xarray
 OBJ: THaVar	BD.xarray8	Bank Data xarray
 OBJ: THaVar	BD.xarray9	Bank Data xarray
 OBJ: THaVar	BD.norf0	Bank Data norf
 OBJ: THaVar	BD.norf1	Bank Data norf
 OBJ: THaVar	BD.norf2	Bank Data norf
 OBJ: THaVar	BD.norf3	Bank Data norf

Notice that rfadc and skip5 are scalars, while 
xarray and norf expand to vectors.

rfadc is from roc20 bank250, the first word

skip5 is from the same roc and bank, but skip 5 words.

xarray is an array of length 10 (the last parameter),
skip the first 8 in roc20 bank250

norf is an array of length 4, skip 0, from roc20 bank8.

This is a first (working) version.  Two issues to work on:

1. Getting database to read from $DB_DIR/YYYYMMDD

2. The banks are not "self-discovered".  There must be at 
least one module (like an FADC) in the db_cratemap.dat for
that roc and that bank, else the bank will not be entered.
