### PR TITLE
Coda3format

### DIFF
--- a/hana_decode/CodaDecoder.h
+++ b/hana_decode/CodaDecoder.h
@@ -27,7 +27,8 @@ public:
   virtual Int_t GetPrescaleFactor(Int_t trigger) const;
   virtual void  SetRunTime(ULong64_t tloc);
 
-  Int_t FindRocs(const UInt_t *evbuffer);
+  Int_t FindRocs(const UInt_t *evbuffer);  // CODA2 version
+  Int_t FindRocsCoda3(const UInt_t *evbuffer); // CODA3 version
   Int_t roc_decode( Int_t roc, const UInt_t* evbuffer, Int_t ipt, Int_t istop );
   Int_t bank_decode( Int_t roc, const UInt_t* evbuffer, Int_t ipt, Int_t istop );
 
@@ -40,11 +41,30 @@ protected:
   std::vector<bool>  fbfound;
   std::vector<Int_t> psfact;
 
+// CODA3 stuff
+  typedef struct trigBankObject {
+     int      blksize;              /* total number of triggers in the Bank */
+     uint16_t tag;                  /* Trigger Bank Tag ID = 0xff2x */
+     uint16_t nrocs;                /* Number of ROC Banks in the Event Block (val = 1-256) */
+     uint32_t len;                  /* Total Length of the Trigger Bank - including Bank header */
+     int      withTimeStamp;        /* =1 if Time Stamps are available */
+     int      withRunInfo;          /* =1 if Run Informaion is available - Run # and Run Type */
+     uint64_t evtNum;               /* Starting Event # of the Block */
+     uint64_t runInfo;              /* Run Info Data */
+     uint32_t *start;               /* Pointer to start of the Trigger Bank */
+     uint64_t *evTS;                /* Pointer to the array of Time Stamps */
+     uint16_t *evType;              /* Pointer to the array of Event Types */
+   } TBOBJ;
+
+  TBOBJ tbank;
+
   void CompareRocs();
   void ChkFbSlot( Int_t roc, const UInt_t* evbuffer, Int_t ipt, Int_t istop );
   void ChkFbSlots();
 
   virtual Int_t init_slotdata();
+  virtual Int_t interpretCoda3(const UInt_t* buffer);
+  virtual Int_t trigBankDecode(const UInt_t *tb, int blkSize);
   Int_t prescale_decode(const UInt_t* evbuffer);
   void dump(const UInt_t* evbuffer) const;
 

--- a/hana_decode/Module.cxx
+++ b/hana_decode/Module.cxx
@@ -19,7 +19,7 @@ namespace Decoder {
 Module::Module()
   : fCrate(0), fSlot(0), fHeader(0), fHeaderMask(0xffffffff), fBank(-1),
     fWordsExpect(0), fWordsSeen(0), fWdcntMask(0), fWdcntShift(0),
-    fModelNum(-1), fNumChan(0), fMode(0),
+    fModelNum(-1), fNumChan(0), fMode(0), block_size(1),
     fMultiBlockMode(kFALSE), fBlockIsDone(kFALSE), fFirmwareVers(0),
     fDebugFile(0), fExtra(0)
 {
@@ -28,7 +28,7 @@ Module::Module()
 Module::Module(Int_t crate, Int_t slot)
   : fCrate(crate), fSlot(slot), fHeader(0), fHeaderMask(0xffffffff), fBank(-1),
     fWordsExpect(0), fWordsSeen(0), fWdcntMask(0), fWdcntShift(0),
-    fModelNum(-1), fNumChan(0), fMode(0),
+    fModelNum(-1), fNumChan(0), fMode(0), block_size(1),
     fMultiBlockMode(kFALSE), fBlockIsDone(kFALSE), fFirmwareVers(0),
     fDebugFile(0), fExtra(0)
 {

--- a/hana_decode/Module.h
+++ b/hana_decode/Module.h
@@ -43,6 +43,8 @@ namespace Decoder {
     Bool_t BlockIsDone() { return fBlockIsDone; };
     virtual void SetFirmware(Int_t fw) {fFirmwareVers=fw;};
 
+    Int_t GetBlockSize() { return block_size; };
+
     // inheriting classes need to implement one or more of these
     virtual UInt_t GetData(Int_t) const { return 0; };
     virtual Int_t GetData(Int_t, Int_t) const { return 0; };
@@ -117,6 +119,7 @@ namespace Decoder {
     Int_t fWordsExpect, fWordsSeen;
     Int_t fWdcntMask, fWdcntShift;
     Int_t fModelNum, fNumChan, fMode;
+    Int_t block_size;
     Bool_t IsInit;
     Bool_t fMultiBlockMode, fBlockIsDone;
     Int_t fFirmwareVers;

--- a/hana_decode/THaCodaData.cxx
+++ b/hana_decode/THaCodaData.cxx
@@ -20,6 +20,7 @@ namespace Decoder {
 
 //_____________________________________________________________________________
 THaCodaData::THaCodaData() {
+   fCodaVersion = 2; // default
    evbuffer = new UInt_t[MAXEVLEN];         // Raw data
 };
 

--- a/hana_decode/THaCodaData.h
+++ b/hana_decode/THaCodaData.h
@@ -46,6 +46,7 @@ public:
    virtual UInt_t* getEvBuffer() { return evbuffer; }
    virtual Int_t getBuffSize() const { return MAXEVLEN; }
    virtual Bool_t isOpen() const = 0;
+   virtual Int_t getCodaVersion() { return fCodaVersion; };
 
 protected:
    static Int_t ReturnCode( Long64_t evio_retcode );
@@ -59,6 +60,7 @@ protected:
 
    TString  filename;
    UInt_t*  evbuffer;     // Raw data
+   Int_t fCodaVersion;
 
    ClassDef(THaCodaData,0) // Base class of CODA data (file, ET conn, etc)
 

--- a/hana_decode/THaCodaFile.cxx
+++ b/hana_decode/THaCodaFile.cxx
@@ -48,6 +48,17 @@ namespace Decoder {
        // _might_ be modified internally ...) Silly, really.
        char *d_fname = strdup(fname), *d_flags = strdup("r");
        Int_t status = evOpen(d_fname,d_flags,&handle);
+       Int_t EvioVersion;
+       Int_t status2 = evIoctl(handle, "v", &EvioVersion);
+       fCodaVersion = 0; 
+       if (status2 == S_SUCCESS) {
+  	   cout << "Evio file EvioVersion = "<< EvioVersion<<endl;
+           if (EvioVersion < 4) {
+               fCodaVersion = 2;
+	   } else { 
+	     fCodaVersion = 3;
+	   }
+       }
        free(d_fname); free(d_flags);
        staterr("open",status);
        return ReturnCode(status);
@@ -58,6 +69,17 @@ namespace Decoder {
       init(fname);
       char *d_fname = strdup(fname), *d_flags = strdup(readwrite);
       Int_t status = evOpen(d_fname,d_flags,&handle);
+      Int_t EvioVersion;
+      Int_t status2 = evIoctl(handle, "v", &EvioVersion);
+      fCodaVersion = 0; 
+      if (status2 == S_SUCCESS) {
+  	  cout << "Evio file EvioVersion = "<< EvioVersion<<endl;
+          if (EvioVersion < 4) {
+              fCodaVersion = 2;
+	  } else { 
+	      fCodaVersion = 3;
+	  }
+      }
       free(d_fname); free(d_flags);
       staterr("open",status);
       return ReturnCode(status);

--- a/hana_decode/THaEvData.h
+++ b/hana_decode/THaEvData.h
@@ -45,6 +45,9 @@ public:
   // Set the EPICS event type
   void      SetEpicsEvtType(Int_t itype) { fEpicsEvtType = itype; };
 
+  // Set the CODA version which affects some decoding behaviour
+  void      SetCodaVersion(Int_t vers) { fCodaVersion = vers; };
+
   // Basic access to the decoded data
   Int_t     GetEvType()   const { return event_type; }
   Int_t     GetEvLength() const { return event_length; }
@@ -237,6 +240,7 @@ protected:
   Bool_t first_decode;
   Bool_t fTrigSupPS;
   Bool_t  fMultiBlockMode, fBlockIsDone;
+  Int_t fCodaVersion;
 
   Int_t fEpicsEvtType;
 
@@ -245,6 +249,7 @@ protected:
   std::ofstream *fDebugFile;  // debug output
 
   Int_t  event_type,event_length,event_num,run_num,evscaler;
+  Int_t  bank_tag, data_type, block_size, tbLen, evcnt_coda3;
   Int_t  run_type;    // CODA run type from prestart event
   ULong64_t fRunTime; // CODA run time (Unix time) from prestart event
   ULong64_t evt_time; // Event time. Not directly supported by CODA

--- a/src/THaAnalyzer.cxx
+++ b/src/THaAnalyzer.cxx
@@ -815,6 +815,9 @@ Int_t THaAnalyzer::ReadOneEvent()
   if (to_read_file)
     status = fRun->ReadEvent();
 
+  // there may be a better place to do this, but this works
+  fEvData->SetCodaVersion(fRun->GetCodaVersion());
+
   switch( status ) {
   case THaRunBase::READ_OK:
     // Decode the event

--- a/src/THaRun.cxx
+++ b/src/THaRun.cxx
@@ -149,6 +149,8 @@ Int_t THaRun::Open()
   }
 
   Int_t st = fCodaData->codaOpen( fFilename );
+  fCodaVersion = fCodaData->getCodaVersion();
+  cout << "in THaRun::Open:  coda version "<<fCodaVersion<<endl;
   if( st == 0 )
     fOpened = kTRUE;
   return ReturnCode( st );
@@ -180,6 +182,7 @@ Int_t THaRun::ReadInitInfo()
       // Disable advanced processing
       evdata->EnableScalers(kFALSE);
       evdata->EnableHelicity(kFALSE);
+      evdata->SetCodaVersion(fCodaVersion);
       UInt_t nev = 0;
       while( nev<fMaxScan && !HasInfo(fDataRequired) &&
 	     (status = ReadEvent()) == READ_OK ) {
@@ -255,6 +258,7 @@ Int_t THaRun::ReadInitInfo()
 	  fSegment  = 0;
 	  if( fCodaData->codaOpen(s) == 0 )
 	    status = ReadInitInfo();
+          fCodaVersion = fCodaData->getCodaVersion();
 	  delete fCodaData;
 	  fSegment  = save_seg;
 	  fCodaData = save_coda;

--- a/src/THaRunBase.h
+++ b/src/THaRunBase.h
@@ -54,6 +54,7 @@ public:
           UInt_t       GetFirstEvent()  const { return fEvtRange[0]; }
           UInt_t       GetLastEvent()   const { return fEvtRange[1]; }
   THaRunParameters*    GetParameters()  const { return fParam; }
+          Int_t        GetCodaVersion() const { return fCodaVersion; }
   virtual Bool_t       HasInfo( UInt_t bits ) const;
   virtual Bool_t       HasInfoRead( UInt_t bits ) const;
           Bool_t       IsInit()         const { return fIsInit; }
@@ -67,6 +68,7 @@ public:
           void         SetEventRange( UInt_t first, UInt_t last );
   virtual void         SetNumber( Int_t number );
           void         SetRunParamClass( const char* classname );
+          void         SetCodaVersion(Int_t ver) { fCodaVersion = ver; }
   virtual void         SetType( Int_t type );
   virtual Int_t        Update( const THaEvData* evdata );
 
@@ -88,6 +90,7 @@ protected:
   UInt_t        fDataSet;       // Flags for info that is valid (see EInfoType)
   UInt_t        fDataRead;      // Flags for info found in data (see EInfoType)
   UInt_t        fDataRequired;  // Info required for Init() to succeed
+  Int_t         fCodaVersion;   // Version of CODA that wrote the data.
   THaRunParameters* fParam;     // Run parameters
   TString       fRunParamClass; // Class of object in fParam
   TObject*      fExtra;         // Additional member data (for binary compat.)


### PR DESCRIPTION
CODA3 and CODA2 data format support

These changes address Feature 274 in Redmine.
https://redmine.jlab.org/issues/274

Specifically, we can now read data files written with CODA 3.* in addition to CODA 2.*.  The decoding of the initial part of the event buffer is different for these versions.  This is explained in the Redmine link.

For testing of this code, I ran on some old data (CODA 2.*) and compared to the results of the code in the master branch.  I did the "all histogram bins identical" test for hundreds of histograms.  For testing with CODA3.* I used my FADC test stand and took data in different modes (9 and 10) and with different block levels (1, 20, and 100) and did a thorough debug.  Looks like it works.

One issue.  I normally do a "git rebase -i master" but git would not allow it because I had uncommitted changes.  I don't want to commit those changes.  Anyway, there's probably a workaround but for now I request that Ole do the rebase if necessary.  I had based this on a pretty recent master branch and had merged.
