### PR TITLE
More simple cmake fix.

### DIFF
--- a/hana_decode/CMakeLists.txt
+++ b/hana_decode/CMakeLists.txt
@@ -9,13 +9,11 @@ set(SUBPROJECT_NAME Decode)
 #----------------------------------------------------------------------------
 # Configuration options
 option(ONLINE_ET "Enable support ET message system" OFF)
-option(EVIO_HAS_CMAKE_CONFIG "Find EVIO only in CMake Config mode" OFF)
 
 #----------------------------------------------------------------------------
 # Required dependencies
-if(EVIO_HAS_CMAKE_CONFIG)
-  find_package(EVIO CONFIG REQUIRED)
-else()
+find_package(EVIO CONFIG)
+if(NOT EVIO_FOUND)
   find_package(EVIO REQUIRED)
 endif()
 


### PR DESCRIPTION
Note that MODULE mode is used first (because it is more customized) then CONFIG mode is used.  Hence the need to force it the other way around until evio uses cmake or pkgconfig.
https://cmake.org/cmake/help/latest/command/find_package.html