### PR TITLE
Add GetEpicsEvtHandler to THaAnalyzer.

### DIFF
--- a/src/THaAnalyzer.h
+++ b/src/THaAnalyzer.h
@@ -56,6 +56,7 @@ public:
   THaEvData*     GetDecoder()          const;
   TList*         GetApps()             const  { return fApps; }
   TList*         GetPhysics()          const  { return fPhysics; }
+  THaEpicsEvtHandler* GetEpicsEvtHandler() { return fEpicsHandler; }
   TList*         GetEvtHandlers()      const  { return fEvtHandlers; }
   TList*         GetPostProcess()      const  { return fPostProcess; }
   Bool_t         HasStarted()          const  { return fAnalysisStarted; }


### PR DESCRIPTION
This will allow objects such as physics modules or detectors to get access to EPICS data.
