### PR TITLE
Setcodavers

### DIFF
--- a/hana_decode/CodaDecoder.cxx
+++ b/hana_decode/CodaDecoder.cxx
@@ -64,8 +64,8 @@ Int_t CodaDecoder::LoadEvent(const UInt_t* evbuffer)
 {
   // Main engine for decoding, called by public LoadEvent() methods
 
-  if (fCodaVersion == 0) {
-     cout << "This makes no sense, coda version zero ??  Exit !!"<<endl;
+  if (fCodaVersion <= 0) {
+     cout << "This makes no sense, coda version "<<fCodaVersion<<" ??  Exit !!"<<endl;
      exit(0);
   }
   event_length = evbuffer[0]+1;  // in longwords (4 bytes)
@@ -627,6 +627,11 @@ Int_t CodaDecoder::FindRocsCoda3(const UInt_t *evbuffer) {
   /* Sanity check:  Check if number of ROCs matches */
   if(nroc != tbank.nrocs) {
       printf(" ****ERROR: Trigger and Physics Block sizes do not match (%d != %d)\n",nroc,tbank.nrocs);
+// If you are reading a data file orignally written with CODA 2 and then
+// processed (written out) with EVIO 4, it will segfault. Do as it says below.
+      printf("This might indicate a file written with EVIO 4 that was a CODA 2 file\n");
+      printf("Try  analyzer->SetCodaVersion(2)  in the analyzer script.\n");
+
   }
 
   if (fDebugFile) {  // debug   

--- a/hana_decode/THaEvData.cxx
+++ b/hana_decode/THaEvData.cxx
@@ -1,4 +1,4 @@
-/////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////
 //
 //   THaEvData
 //   Hall A Event Data from One "Event"
@@ -60,7 +60,7 @@ THaEvData::THaEvData() :
   fMap(0), first_decode(true), fTrigSupPS(true),
   fMultiBlockMode(kFALSE), fBlockIsDone(kFALSE),
   buffer(0), fDebugFile(0), run_num(0), run_type(0), fRunTime(0),
-  evt_time(0), recent_event(0), 
+  evt_time(0), recent_event(0), fCodaVersion(0), 
   buffmode(false), synchmiss(false), synchextra(false),
   fNSlotUsed(0), fNSlotClear(0), 
   fDoBench(kFALSE), fBench(0), fNeedInit(true), fDebug(0), fExtra(0)
@@ -240,6 +240,17 @@ void THaEvData::hexdump(const char* cbuff, size_t nlen)
     } cout << endl;
     p += NW;
   }
+}
+
+void THaEvData::SetCodaVersion(Int_t vers)
+{
+  if (vers != 2 && vers != 3) {
+    cout << "ERROR::THaEvData::SetCodaVersion version "<<vers;
+    cout << "  must be 2 or 3 only."<<endl;
+    cout << "Not setting CODA version ! "<<endl;
+    return;
+  }
+  fCodaVersion = vers;
 }
 
 void THaEvData::SetDefaultCrateMapName( const char* name )

--- a/hana_decode/THaEvData.h
+++ b/hana_decode/THaEvData.h
@@ -48,7 +48,8 @@ public:
   void      SetEpicsEvtType(Int_t itype) { fEpicsEvtType = itype; };
 
   // Set the CODA version which affects some decoding behaviour
-  void      SetCodaVersion(Int_t vers) { fCodaVersion = vers; };
+  void      SetCodaVersion(Int_t vers);
+  Int_t     GetCodaVersion() const { return fCodaVersion; }
 
   // Basic access to the decoded data
   Int_t     GetEvType()   const { return event_type; }

--- a/src/THaAnalyzer.cxx
+++ b/src/THaAnalyzer.cxx
@@ -81,7 +81,7 @@ THaAnalyzer::THaAnalyzer() :
   fIsInit(kFALSE), fAnalysisStarted(kFALSE), fLocalEvent(kFALSE),
   fUpdateRun(kTRUE), fOverwrite(kTRUE), fDoBench(kFALSE),
   fDoHelicity(kFALSE), fDoPhysics(kTRUE), fDoOtherEvents(kTRUE),
-  fDoSlowControl(kTRUE), fExtra(0)
+  fDoSlowControl(kTRUE), fExtra(0), fWantCodaVers(-1)
 
 {
   // Default constructor.
@@ -504,6 +504,8 @@ Int_t THaAnalyzer::DoInit( THaRunBase* run )
   static const char* const here = "Init";
   Int_t retval = 0;
 
+  if (fWantCodaVers > 0) run->SetCodaVersion(fWantCodaVers);
+
   //--- Open the output file if necessary so that Trees and Histograms
   //    are created on disk.
 
@@ -610,6 +612,8 @@ Int_t THaAnalyzer::DoInit( THaRunBase* run )
     }
     new_decoder = true;
   }
+
+  if (fWantCodaVers > 0) fEvData->SetCodaVersion(fWantCodaVers);
 
   // Make sure the run is initialized.
   bool run_init = false;
@@ -816,7 +820,11 @@ Int_t THaAnalyzer::ReadOneEvent()
     status = fRun->ReadEvent();
 
   // there may be a better place to do this, but this works
-  fEvData->SetCodaVersion(fRun->GetCodaVersion());
+  if (fWantCodaVers > 0) {
+    fEvData->SetCodaVersion(fWantCodaVers);
+  } else {
+    fEvData->SetCodaVersion(fRun->GetCodaVersion());
+  }
 
   switch( status ) {
   case THaRunBase::READ_OK:
@@ -1509,6 +1517,19 @@ Int_t THaAnalyzer::Process( THaRunBase* run )
   //  gHaRun = NULL;
   return fNev;
 }
+
+//_____________________________________________________________________________
+void THaAnalyzer::SetCodaVersion(Int_t vers)
+{
+  if (vers != 2 && vers != 3) {
+    cout << "ERROR:THaRunBase:SetCodaVersion versions must be 2 or 3"<<endl;
+    cout << "Setting version = 2 by default "<<endl;
+    fWantCodaVers = 2; 
+    return;
+  }
+  fWantCodaVers = vers;
+}
+
 
 //_____________________________________________________________________________
 

--- a/src/THaAnalyzer.h
+++ b/src/THaAnalyzer.h
@@ -74,6 +74,7 @@ public:
   void           SetCompressionLevel( Int_t level ) { fCompress = level; }
   void           SetMarkInterval( UInt_t interval ) { fMarkInterval = interval; }
   void           SetVerbosity( Int_t level )        { fVerbose = level; }
+  void           SetCodaVersion(Int_t vers);
 
   // Set the EPICS event type
   void           SetEpicsEvtType(Int_t itype);
@@ -125,6 +126,7 @@ protected:
   THaEvent*      fEvent;           //The event structure to be written to file.
   Int_t          fNStages;         //Number of analysis stages
   Int_t          fNCounters;       //Number of counters
+  Int_t          fWantCodaVers;    // Version of CODA assumed for file
   Stage_t*       fStages;          //[fNStages] Parameters for analysis stages
   Counter_t*     fCounters;        //[fNCounters] Statistics counters
   UInt_t         fNev;             //Number of events read during most recent replay

--- a/src/THaRun.cxx
+++ b/src/THaRun.cxx
@@ -149,7 +149,9 @@ Int_t THaRun::Open()
   }
 
   Int_t st = fCodaData->codaOpen( fFilename );
-  fCodaVersion = fCodaData->getCodaVersion();
+// Get fCodaVersion from data; however, if it was already defined
+// by the analyzer script use that instead.
+  if (fCodaVersion == 0) fCodaVersion = fCodaData->getCodaVersion();
   cout << "in THaRun::Open:  coda version "<<fCodaVersion<<endl;
   if( st == 0 )
     fOpened = kTRUE;

--- a/src/THaRunBase.cxx
+++ b/src/THaRunBase.cxx
@@ -30,7 +30,7 @@ THaRunBase::THaRunBase( const char* description ) :
   fNumber(-1), fType(0), fDate(UNDEFDATE,0), fNumAnalyzed(0),
   fDBRead(kFALSE), fIsInit(kFALSE), fOpened(kFALSE), fAssumeDate(kFALSE), 
   fDataSet(0), fDataRead(0), fDataRequired(kDate), fParam(0),
-  fRunParamClass(DEFRUNPARAM), fExtra(0)
+  fRunParamClass(DEFRUNPARAM), fExtra(0), fCodaVersion(0)
 {
   // Normal & default constructor
 
@@ -339,9 +339,9 @@ Int_t THaRunBase::Init()
       msg++;
     }
     errtxt += ". Run not initialized.";
-    Error( here, "%s", errtxt.Data() );
+    //    Error( here, "%s", errtxt.Data() );  // temp !!
 
-    return READ_FATAL;
+    return READ_OK;  // temp !!
   }
 
   // Read the database to obtain additional parameters that are not set

--- a/src/THaRunBase.cxx
+++ b/src/THaRunBase.cxx
@@ -339,9 +339,9 @@ Int_t THaRunBase::Init()
       msg++;
     }
     errtxt += ". Run not initialized.";
-    //    Error( here, "%s", errtxt.Data() );  // temp !!
+    Error( here, "%s", errtxt.Data() );  
 
-    return READ_OK;  // temp !!
+    return READ_FATAL;  
   }
 
   // Read the database to obtain additional parameters that are not set

--- a/src/THaRunBase.h
+++ b/src/THaRunBase.h
@@ -68,7 +68,7 @@ public:
           void         SetEventRange( UInt_t first, UInt_t last );
   virtual void         SetNumber( Int_t number );
           void         SetRunParamClass( const char* classname );
-          void         SetCodaVersion(Int_t ver) { fCodaVersion = ver; }
+          void         SetCodaVersion(Int_t vers) { fCodaVersion = vers; }
   virtual void         SetType( Int_t type );
   virtual Int_t        Update( const THaEvData* evdata );
 


### PR DESCRIPTION
Allow analyzer script to over-ride the CODA version with a command like analyzer->SetCodaVersion(2).  This was described in detail in issue 407 of redmine.  These changes mitigate that problem.