### PR TITLE
Scalerfix1

### DIFF
--- a/Podd/THaScalerEvtHandler.cxx
+++ b/Podd/THaScalerEvtHandler.cxx
@@ -56,23 +56,6 @@ using namespace std;
 using namespace Decoder;
 using namespace THaString;
 
-static const UInt_t ICOUNT    = 1;
-static const UInt_t IRATE     = 2;
-static const UInt_t MAXCHAN   = 32;
-static const UInt_t MAXTEVT   = 5000;
-static const UInt_t defaultDT = 4;
-
-class ScalerLoc { // Utility class used by THaScalerEvtHandler
- public:
-  ScalerLoc(const TString& nm, const TString& desc, Int_t idx, Int_t sl,
-      Int_t ich, Int_t iki, Int_t iv)
-   : name(nm), description(desc), index(idx), islot(sl), ichan(ich),
-     ikind(iki), ivar(iv) {};
-  ~ScalerLoc();
-  TString name, description;
-  UInt_t index, islot, ichan, ikind, ivar;
-};
-
 THaScalerEvtHandler::THaScalerEvtHandler(const char *name,
     const char* description)
   : THaEvtTypeHandler(name,description), evcount(0), fNormIdx(-1),

--- a/Podd/THaScalerEvtHandler.h
+++ b/Podd/THaScalerEvtHandler.h
@@ -14,8 +14,25 @@
 #include <vector>
 #include "TString.h"  
 
-class ScalerLoc;
 class TTree;
+
+static const UInt_t ICOUNT    = 1;
+static const UInt_t IRATE     = 2;
+static const UInt_t MAXCHAN   = 32;
+static const UInt_t MAXTEVT   = 5000;
+static const UInt_t defaultDT = 4;
+
+class ScalerLoc { // Utility class used by THaScalerEvtHandler
+ public:
+  ScalerLoc(const TString& nm, const TString& desc, Int_t idx, Int_t sl,
+      Int_t ich, Int_t iki, Int_t iv)
+   : name(nm), description(desc), index(idx), islot(sl), ichan(ich),
+     ikind(iki), ivar(iv) {};
+  ~ScalerLoc();
+  TString name, description;
+  UInt_t index, islot, ichan, ikind, ivar;
+};
+
 
 class THaScalerEvtHandler : public THaEvtTypeHandler {
 
@@ -29,7 +46,7 @@ public:
    virtual Int_t End( THaRunBase* r=0 );
 
 
-private:
+protected:
 
    void AddVars(const TString& name, const TString& desc, Int_t iscal,
        Int_t ichan, Int_t ikind);

--- a/hana_decode/GenScaler.cxx
+++ b/hana_decode/GenScaler.cxx
@@ -26,6 +26,7 @@ namespace Decoder {
       fHasClock(false), fClockRate(0), fNormScaler(0)
   {
     fWordsExpect = 32;
+    fNumChan = 0;
   }
 
   void GenScaler::Clear(Option_t* opt) {
@@ -128,10 +129,11 @@ namespace Decoder {
       doload=1;
       memcpy(fPrevData, fDataArray, fWordsExpect*sizeof(UInt_t));
     }
-    if (fDebugFile) *fDebugFile << "is slot 0x"<<hex<<*evbuffer<<dec<<endl;
-    fIsDecoded = kTRUE;
+    if ( !IsSlot(*evbuffer) ) return nfound;
+    if (fDebugFile) *fDebugFile << "is slot 0x"<<hex<<*evbuffer<<dec<<" num chan "<<fNumChan<<endl;
     evbuffer++;
-    for (Int_t i=0; i<fWordsExpect; i++) {
+    fIsDecoded = kTRUE;
+    for (Int_t i=0; i<fNumChan; i++) {
       fDataArray[i] = *(evbuffer++);
       nfound++;
       if (fDebugFile) *fDebugFile << "   data["<<i<<"] = 0x"<<hex<<fDataArray[i]<<dec<<endl;
@@ -256,7 +258,7 @@ namespace Decoder {
 
       // Print warning once to alert user to potential problems,
       // or for every suspect event if debugging enabled
-      if( firstwarn || fDebugFile ) {
+      if( firstwarn && fNumChan!=16 && fNumChan!=fWordsExpect) {
 	cout << "GenScaler:: ERROR:  (" << fCrate << "," << fSlot << ") "
 	     << "inconsistent number of chan."<<endl;
 	//        DoPrint();


### PR DESCRIPTION
There are two changes here which we need for the "official" analyzer on the counting house computers.  These pertain to Scaler analysis.  
1. THaScalerEvtHandler must allow for inheritance.  
2. GenScaler had a problem that if it was not fed the header word for the first word, it would do something wrong.
I think Tritium must have fixed these things privately, as I see in a "TriScaler" library.