### PR TITLE
Increase MAXCHAN and MAXDATA limit for MPD

### DIFF
--- a/hana_decode/THaCrateMap.cxx
+++ b/hana_decode/THaCrateMap.cxx
@@ -56,8 +56,8 @@ static string StrError()
 
 namespace Decoder {
 
-const UShort_t THaCrateMap::MAXCHAN = 4096;
-const UShort_t THaCrateMap::MAXDATA = 32768;
+const UShort_t THaCrateMap::MAXCHAN = 8192;
+const UShort_t THaCrateMap::MAXDATA = 65536;
 const int THaCrateMap::CM_OK = 1;
 const int THaCrateMap::CM_ERR = -1;
 


### PR DESCRIPTION
If MPD is used in slot 16, then we reach the MAXCHAN limit. Please increase this limit.
This was happend earlier and Seamus had requested increase these values (comit 4cbd410).