### PR TITLE
Bugfix for CODA3 file and some improvements

### DIFF
--- a/Podd/THaOutput.cxx
+++ b/Podd/THaOutput.cxx
@@ -168,7 +168,7 @@ void THaOdata::AddBranches( TTree* _tree, string _name )
 //_____________________________________________________________________________
 Bool_t THaOdata::Resize(Int_t i)
 {
-  static const Int_t MAX = 4096;
+  static const Int_t MAX = 1<<16;
   if( i > MAX ) return true;
   Int_t newsize = nsize;
   while ( i >= newsize ) { newsize *= 2; } 

--- a/cmake/Modules/PoddCompileInfo.cmake
+++ b/cmake/Modules/PoddCompileInfo.cmake
@@ -16,7 +16,8 @@ if(NOT GET_COMPILEINFO)
     "PoddCompileInfo: Cannot find ${_compileinfo_cmd}. Check your Podd installation.")
 endif()
 
-execute_process(COMMAND "${GET_COMPILEINFO}" "${CMAKE_CXX_COMPILER}"
+
+execute_process(COMMAND "${GET_COMPILEINFO}" "${CMAKE_CXX_COMPILER}" "${CMAKE_SOURCE_DIR}"
   OUTPUT_VARIABLE _compileinfo_out
   ERROR_VARIABLE _compileinfo_err
   OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/cmake/scripts/get_compileinfo.sh
+++ b/cmake/scripts/get_compileinfo.sh
@@ -4,6 +4,7 @@
 #
 # Command line arguments:
 #   $1: C++ compiler command
+#   $2: the path to this git repository (for out of source builds)
 # Output:
 #   Exactly 7 lines
 #    date
@@ -19,6 +20,11 @@ date -u "+%a %b %d %H:%M:%S %Z %Y"
 echo $(uname -s)-$(uname -r)-$(uname -m)
 uname -n
 whoami
-gitrev=$(git rev-parse --short HEAD 2>/dev/null)
+repo_path=""
+if [ ! -z "$2" ];
+then
+  repo_path="-C $2"
+fi
+gitrev=$(git ${repo_path} rev-parse --short HEAD 2>/dev/null)
 [ -n "$gitrev" ] && echo $gitrev || echo ""
 $1 --version 2>/dev/null | head -1

--- a/hana_decode/CodaDecoder.cxx
+++ b/hana_decode/CodaDecoder.cxx
@@ -221,6 +221,7 @@ Int_t CodaDecoder::interpretCoda3(const UInt_t* evbuffer)
   	    event_type = END_EVTYPE;
 	    break;
      case 0xff50:
+     case 0xff58: // Physics event with sync bit
      case 0xff70:
   	    event_type=1;  // Physics event type
 	    break;
@@ -622,7 +623,7 @@ Int_t CodaDecoder::FindRocsCoda3(const UInt_t *evbuffer) {
 
   while (pos < event_length) {
     Int_t len = (evbuffer[pos]+1);               /* total Length of ROC Bank */
-    Int_t iroc = (evbuffer[pos+1]&0xffff0000)>>16;   /* ID of ROC */
+    Int_t iroc = (evbuffer[pos+1]&0x0fff0000)>>16;   /* ID of ROC is 12 bits*/
     rocdat[iroc].len = len;
     rocdat[iroc].pos = pos;
     irn[nroc] = iroc;


### PR DESCRIPTION
- Bugfix: Fix ROCID so it only looks at 12 bits (previously using 16 bits mistakenly include the sync bit).
- Bugfix: Accept event type 0xFF58 which has a sync bit in the tag.
- Improvement: small change to allow cmake to be built in a out of source build directory.
- Improvement: Increase output vector size to 65536 (previously 4096).