### PR TITLE
#188 docker container for halla analyzer

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    tags: [1*]
+    tags: ['**']
 
 jobs:
   docker:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,38 @@
+name: Docker Image CI
+
+on:
+  push:
+    tags: [1*]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: jeffersonlab/analyzer
+      -
+        name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      -
+        name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: "{{defaultContext}}"
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            DOCKER_TAG=${{ steps.meta.outputs.tags }}
+            APP_VERSION=${{ github.ref_name}}
+            REPO_NAME=${{ github.event.repository.name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM centos:centos7
+
+ARG APP_VERSION
+ARG REPO_NAME
+
+RUN yum -y install git && \
+    yum -y groupinstall 'Development Tools'&& \
+    yum -y install gcc-c++ && \
+    yum -y install make \
+    yum install -y root \
+    && localedef -i en_US -f UTF-8 en_US.UTF-8
+
+ADD https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2-linux-x86_64.tar.gz .
+RUN tar -xvf cmake-3.22.2-linux-x86_64.tar.gz
+RUN mv cmake-3.22.2-linux-x86_64 /usr/local/cmake
+RUN ls -l /usr/local/cmake/bin
+ENV PATH="/usr/local/cmake/bin:$PATH"
+ADD https://github.com/panta-123/${REPO_NAME}/archive/refs/tags/${APP_VERSION}.tar.gz .
+RUN tar -xvf ${APP_VERSION}.tar.gz
+WORKDIR "/${REPO_NAME}-${APP_VERSION}"
+RUN mkdir -p $HOME/local/analyzer
+RUN cmake -DCMAKE_INSTALL_PREFIX=$HOME/local/analyzer -B builddir -S /${REPO_NAME}-${APP_VERSION}/
+RUN cmake --build builddir -j8
+RUN cmake --install builddir
+ENV PATH="~/local/analyzer/bin:$PATH"
+ENV LD_LIBRARY_PATH="~/local/analyzer/lib:$LD_LIBRARY_PATH"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,5 @@ RUN cmake --install BUILD
 ENV LD_LIBRARY_PATH="/usr/local/analyzer/lib64:$LD_LIBRARY_PATH"
 ENV ANALYZER="/usr/local/analyzer"
 ENV PATH="/usr/local/analyzer/bin:/usr/bin/root:$PATH"
-ENV LD_LIBRARY_PATH="/usr/local/analyzer/lib64:$LD_LIBRARY_PATH"
 ENV ROOTSYS="/usr/"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN yum -y install epel-release &&\
     yum -y install gcc-c++ && \
     yum -y install make && \
     yum install -y root && \
+    yum install -y which && \
+    yum install -y root-montecarlo-eg && \
+    yum install -y root-montecarlo-pythia8 && \
     localedef -i en_US -f UTF-8 en_US.UTF-8
 
 ADD https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2-linux-x86_64.tar.gz .
@@ -20,10 +23,16 @@ ENV PATH="/usr/local/cmake/bin:$PATH"
 ADD https://github.com/JeffersonLab/${REPO_NAME}/archive/refs/tags/${APP_VERSION}.tar.gz .
 RUN tar -xvf ${APP_VERSION}.tar.gz && rm ${APP_VERSION}.tar.gz
 WORKDIR "/${REPO_NAME}-${APP_VERSION}"
-RUN cmake -DCMAKE_INSTALL_PREFIX=/usr/local/analyzer -B builddir -S /${REPO_NAME}-${APP_VERSION}/
-RUN cmake --build builddir -j8
-RUN cmake --install builddir
-ENV CMAKE_INSTALL_PREFIX="/usr/local/analyzers"
-ENV PATH="/usr/local/analyzer/bin:$PATH"
+RUN cmake -DCMAKE_INSTALL_PREFIX=/usr/local/analyzer -B BUILD -S /${REPO_NAME}-${APP_VERSION}/
+RUN cmake --build BUILD -j8
+RUN cmake --install BUILD
+ENV CMAKE_INSTALL_PREFIX="/usr/local/analyzer"
 ENV LD_LIBRARY_PATH="/usr/local/analyzer/lib64:$LD_LIBRARY_PATH"
+ENV ANALYZER="/usr/local/analyzer"
+ENV PATH="/usr/local/analyzer/bin:/usr/bin/root:$PATH"
+ENV LD_LIBRARY_PATH="/usr/local/analyzer/lib64:$LD_LIBRARY_PATH"
+ENV PATH="/${REPO_NAME}-${APP_VERSION}/BUILD/apps:${PATH}"
+ENV LD_LIBRARY_PATH="/${REPO_NAME}-${APP_VERSION}/BUILD/HallA:/${REPO_NAME}-${APP_VERSION}/BUILD/Podd:/${REPO_NAME}-${APP_VERSION}/BUILD/hana_decode:/${REPO_NAME}-${APP_VERSION}/BUILD/Database:${LD_LIBRARY_PATH}"
+ENV ROOT_INCLUDE_PATH="/${REPO_NAME}-${APP_VERSION}/HallA:/${REPO_NAME}-${APP_VERSION}/Podd:/${REPO_NAME}-${APP_VERSION}/hana_decode:/${REPO_NAME}-${APP_VERSION}/Database:${ROOT_INCLUDE_PATH}"
+ENV ROOTSYS="/usr/"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ RUN yum -y install epel-release &&\
     yum -y install make && \
     yum install -y root && \
     yum install -y which && \
-    yum install -y root-montecarlo-eg && \
-    yum install -y root-montecarlo-pythia8 && \
+    yum install -y root-montecarlo-eg &&  \
     localedef -i en_US -f UTF-8 en_US.UTF-8
 
 ADD https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2-linux-x86_64.tar.gz .
@@ -26,13 +25,9 @@ WORKDIR "/${REPO_NAME}-${APP_VERSION}"
 RUN cmake -DCMAKE_INSTALL_PREFIX=/usr/local/analyzer -B BUILD -S /${REPO_NAME}-${APP_VERSION}/
 RUN cmake --build BUILD -j8
 RUN cmake --install BUILD
-ENV CMAKE_INSTALL_PREFIX="/usr/local/analyzer"
 ENV LD_LIBRARY_PATH="/usr/local/analyzer/lib64:$LD_LIBRARY_PATH"
 ENV ANALYZER="/usr/local/analyzer"
 ENV PATH="/usr/local/analyzer/bin:/usr/bin/root:$PATH"
 ENV LD_LIBRARY_PATH="/usr/local/analyzer/lib64:$LD_LIBRARY_PATH"
-ENV PATH="/${REPO_NAME}-${APP_VERSION}/BUILD/apps:${PATH}"
-ENV LD_LIBRARY_PATH="/${REPO_NAME}-${APP_VERSION}/BUILD/HallA:/${REPO_NAME}-${APP_VERSION}/BUILD/Podd:/${REPO_NAME}-${APP_VERSION}/BUILD/hana_decode:/${REPO_NAME}-${APP_VERSION}/BUILD/Database:${LD_LIBRARY_PATH}"
-ENV ROOT_INCLUDE_PATH="/${REPO_NAME}-${APP_VERSION}/HallA:/${REPO_NAME}-${APP_VERSION}/Podd:/${REPO_NAME}-${APP_VERSION}/hana_decode:/${REPO_NAME}-${APP_VERSION}/Database:${ROOT_INCLUDE_PATH}"
 ENV ROOTSYS="/usr/"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,25 +3,27 @@ FROM centos:centos7
 ARG APP_VERSION
 ARG REPO_NAME
 
-RUN yum -y install git && \
+RUN yum update -q -y
+
+RUN yum -y install epel-release &&\
+    yum -y install git && \
     yum -y groupinstall 'Development Tools'&& \
     yum -y install gcc-c++ && \
-    yum -y install make \
-    yum install -y root \
-    && localedef -i en_US -f UTF-8 en_US.UTF-8
+    yum -y install make && \
+    yum install -y root && \
+    localedef -i en_US -f UTF-8 en_US.UTF-8
 
 ADD https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2-linux-x86_64.tar.gz .
-RUN tar -xvf cmake-3.22.2-linux-x86_64.tar.gz
+RUN tar -xvf cmake-3.22.2-linux-x86_64.tar.gz && rm cmake-3.22.2-linux-x86_64.tar.gz
 RUN mv cmake-3.22.2-linux-x86_64 /usr/local/cmake
-RUN ls -l /usr/local/cmake/bin
 ENV PATH="/usr/local/cmake/bin:$PATH"
-ADD https://github.com/panta-123/${REPO_NAME}/archive/refs/tags/${APP_VERSION}.tar.gz .
-RUN tar -xvf ${APP_VERSION}.tar.gz
+ADD https://github.com/JeffersonLab/${REPO_NAME}/archive/refs/tags/${APP_VERSION}.tar.gz .
+RUN tar -xvf ${APP_VERSION}.tar.gz && rm ${APP_VERSION}.tar.gz
 WORKDIR "/${REPO_NAME}-${APP_VERSION}"
-RUN mkdir -p $HOME/local/analyzer
-RUN cmake -DCMAKE_INSTALL_PREFIX=$HOME/local/analyzer -B builddir -S /${REPO_NAME}-${APP_VERSION}/
+RUN cmake -DCMAKE_INSTALL_PREFIX=/usr/local/analyzer -B builddir -S /${REPO_NAME}-${APP_VERSION}/
 RUN cmake --build builddir -j8
 RUN cmake --install builddir
-ENV PATH="~/local/analyzer/bin:$PATH"
-ENV LD_LIBRARY_PATH="~/local/analyzer/lib:$LD_LIBRARY_PATH"
+ENV CMAKE_INSTALL_PREFIX="/usr/local/analyzers"
+ENV PATH="/usr/local/analyzer/bin:$PATH"
+ENV LD_LIBRARY_PATH="/usr/local/analyzer/lib64:$LD_LIBRARY_PATH"
 


### PR DESCRIPTION
automatic docker container creation for analyzer. Container will be created when a new tag is pushed to github.

we need to add following to gihub secrets.
1. `DOCKERHUB_USERNAME`
2. `DOCKERHUB_TOKEN `
you can get the docken from docker hub.

Checkout the docker image here for validation: https://hub.docker.com/r/apanta123/hallaana 
Things to be discussed:

- [ ] Do we need multi platform build? (amd64 / arm64) ?
If yes , I will add it to github action .

- [ ] What should be the entry point command.? 
When the user run the docker, currently there is no any entrypoint command they have to specifiy it. 
like `docker run -it apanta123/hallaana:beta bash`
I am thinking that it should be `analyzer`. 

- [ ] What other path needs to added in container? 
In setup.sh i see following:

```
export ANALYZER="@CMAKE_INSTALL_PREFIX@"
export PATH="$ANALYZER/@CMAKE_INSTALL_BINDIR@${PATH:+:$PATH}"
export @DY@LD_LIBRARY_PATH="$ANALYZER/@CMAKE_INSTALL_LIBDIR@${@DY@LD_LIBRARY_PATH:+:$@DY@LD_LIBRARY_PATH}"
export ROOT_INCLUDE_PATH="$ANALYZER/@CMAKE_INSTALL_INCLUDEDIR@${ROOT_INCLUDE_PATH:+:$ROOT_INCLUDE_PATH}"
export CMAKE_PREFIX_PATH="$ANALYZER${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
```
currently in docker we have:
```
ENV PATH="~/local/analyzer/bin:$PATH"
ENV LD_LIBRARY_PATH="~/local/analyzer/lib:$LD_LIBRARY_PATH"
```
 