### PR TITLE
Corrects order of optional data words in Built Trigger Bank

### DIFF
--- a/hana_decode/CodaDecoder.cxx
+++ b/hana_decode/CodaDecoder.cxx
@@ -806,7 +806,7 @@ uint32_t CodaDecoder::TBOBJ::Fill( const uint32_t* evbuffer,
     memcpy(&evtNum, p + 1, sizeof(evtNum));
     evTS = withTimeStamp() ? p + 3 : nullptr;
     if( withRunInfo() )
-      memcpy(&runInfo, p + (evTS ? 2*(blksize-1)+5  : 3), sizeof(runInfo));
+      memcpy(&runInfo, p + 3 + (evTS ? 2*(blksize)  : 0), sizeof(runInfo));
     p += slen + 1;
   }
   if( p-evbuffer >= len )

--- a/hana_decode/CodaDecoder.cxx
+++ b/hana_decode/CodaDecoder.cxx
@@ -804,9 +804,9 @@ uint32_t CodaDecoder::TBOBJ::Fill( const uint32_t* evbuffer,
     if( slen != 2*(1 + (withRunInfo() ? 1 : 0) + (withTimeStamp() ? blkSize : 0)))
       throw coda_format_error("Invalid length for Trigger Bank seg 1");
     memcpy(&evtNum, p + 1, sizeof(evtNum));
+    evTS = withTimeStamp() ? p + 3 : nullptr;
     if( withRunInfo() )
-      memcpy(&runInfo, p + 3, sizeof(runInfo));
-    evTS = withTimeStamp() ? p + 3 + (withRunInfo() ? 2 : 0) : nullptr;
+      memcpy(&runInfo, p + (evTS ? 2*(blksize-1)+5  : 3), sizeof(runInfo));
     p += slen + 1;
   }
   if( p-evbuffer >= len )


### PR DESCRIPTION
### Background:
A built physics event trigger bank contains a common 64bit segment generated by the event-builder. This bank contains the event number, an optional array of average timestamps (array size depends on the block level / size), and an optional "run info" word whose upper 32 bits contain the run number and lower 32 bits contain the run type. The ordering of these optional words is such that the array of timestamps are stored before the run info word (see pg. 11 of the ["CODA Online Data Formats" document](https://coda.jlab.org/drupal/system/files/eventbuilding.pdf)). 

### Issue:
The CodaDecoder::TBOBJ::Fill routine incorrectly expects the run info word to come before the timestamp array. This PR re-arranges the ordering to the correct sequence. The pointer arithmetic has been adjusted accordingly. 

### Validation:
I do not have a working analyzer setup available; however, I checked the pointer arithmetic by hand using data obtained from a software-based CODA setup with a block size set to 5.
```
Block Size = 5

magic word (c0da 0100):  dac0 0001
0000070 0000 1f00 23ff 0120 0a01 0e00 0000 0000
0000080 0000 0100 0000 0000 3412 7856 0000 0000
0000090 3412 7856 0000 0000 3412 7856 0000 0000
00000a0 3412 7856 0000 0000 3412 7856 0000 0400
00000b0 0000 0100 8501 0300

Tag = ff23 (Built Trigger Bank w/ timestamps and run info)

0x70 => 0000 1f00 (evbuffer)
0x74 => 23ff 0120
0x78 => 0a01 0e00 (segment 1)
0x7c => 0000 0000 (evNum  , upper 32bit )
0x80 => 0000 0100 (evNum  , lower 32bit )
0x84 => 0000 0000 (TS 0   , upper 32bits)
0x88 => 3412 7856 (TS 0   , lower 32bits)
0x8c => 0000 0000 (TS 1   , upper 32bits)
0x90 => 3412 7856 (TS 1   , lower 32bits)
0x94 => 0000 0000 (TS 2   , upper 32bits)
0x98 => 3412 7856 (TS 2   , lower 32bits)
0x9c => 0000 0000 (TS 3   , upper 32bits)
0xa0 => 3412 7856 (TS 3   , lower 32bits)
0xa4 => 0000 0000 (TS 4   , upper 32bits)
0xa8 => 3412 7856 (TS 4   , lower 32bits)
0xac => 0000 0400 (RunInfo, upper 32bits)
0xb0 => 0000 0100 (RunInfo, lower 32bits)
0xb4 => 8501 0300 (Segment 2)


evbuffer = 0x70
p = evbuffer + 2*(0x04) = 0x78

// Getting evtNum
memcpy(&evtNum, p + 1, sizeof(uint64_t)) =
memcpy(&evtNum, 0x7c , sizeof(uint64_t)) = copies 0x7c & 0x80

// Getting evTS
evTS = p + 3
evTS = 0x78 + 3*(0x04)
evTS = 0x78 + (0x0c)
evTS = 0x84

// GetEvTS( 3 )
memcpy(&ts, evTS + 2*3     , sizeof(uint64_t)) = 
memcpy(&ts, 0x84 + 6*(0x04), sizeof(uint64_t)) =
memcpy(&ts, 0x84 + 0x18    , sizeof(uint64_t)) =
memcpy(&ts, 0x9c           , sizeof(uint64_t)) = copies 0x9c & 0xa0

// Getting runInfo
if( withTimeStamp() == true)
memcpy(&runInfo, p + 3 + 2*(blksize)    , sizof(uint64_t)) = 
memcpy(&runInfo, 0x78 + 3 + 2*(5)       , sizof(uint64_t)) = 
memcpy(&runInfo, 0x78 + 13*(0x04)       , sizof(uint64_t)) = 
memcpy(&runInfo, 0x78 + 0x34            , sizof(uint64_t)) = 
memcpy(&runInfo, 0xac                   , sizof(uint64_t)) = copies 0xac & 0xb0


if( withTimeStamp() == false)
0x70 => 0000 1f00 (evbuffer)
0x74 => 23ff 0120
0x78 => 0a01 0e00 (segment 1)
0x7c => 0000 0000 (evNum  , upper 32bit )
0x80 => 0000 0100 (evNum  , lower 32bit )
0x84 => 0000 0400 (RunInfo, upper 32bits)
0x88 => 0000 0100 (RunInfo, lower 32bits)
0x8c => 8501 0300 (Segment 2)

// Getting runInfo (evTS == nullptr)
memcpy(&runInfo, p    + 3       , sizof(uint64_t)) = 
memcpy(&runInfo, 0x78 + 3*(0x04), sizof(uint64_t)) = 
memcpy(&runInfo, 0x78 + 0x0c    , sizof(uint64_t)) = 
memcpy(&runInfo, 0x84           , sizof(uint64_t)) = copies 0x84 & 0x88
```